### PR TITLE
Improve test execution speed and cost

### DIFF
--- a/test/rescue.test.mjs
+++ b/test/rescue.test.mjs
@@ -27,7 +27,7 @@ describe("Token Rescue", function () {
         initialOperatorAccountBalance = await getOperatorAccountBalanceSDK(clientOperatorForProperties);
         accounts = await createAccounts(200, 100);
         operatorAccountBalanceAfterAccountsCreation = await getOperatorAccountBalanceSDK(clientOperatorForProperties);
-        accountClient = getClient();;
+        accountClient = getClient();
         accountClient.setOperator(accounts.account.accountId, accounts.account.privateECDSAKey);
         deployedContracts = await deployContracts(tokenName, tokenSymbol, tokenDecimals, accounts, accountClient);
         operatorAccountBalanceAfterContractsDeployment = await getOperatorAccountBalanceSDK(clientOperatorForProperties);

--- a/test/utils_sdk.mjs
+++ b/test/utils_sdk.mjs
@@ -223,8 +223,7 @@ async function deleteContractSDK(contractToDelete, accountToRecoverHbar) {
     const txResponse = await transaction.execute(accountOperatorForProperties);
     await txResponse.getReceipt(accountOperatorForProperties);
 }
-async function deployContractSDK(bytecode, chunks, accounts, constructorParameters, clientOperator, accountClient) {
-    const bytecodeFileId = await fileCreate(bytecode, chunks, accounts.account.privateECDSAKey, clientOperator);
+async function deployContractSDK(bytecodeFileId, accounts, constructorParameters, accountClient) {
     const transaction = new ContractCreateTransaction()
         .setGas(181_000)
         .setBytecodeFileId(bytecodeFileId)
@@ -243,7 +242,7 @@ async function deployContractSDK(bytecode, chunks, accounts, constructorParamete
     return contractId;
 }
 
-async function fileCreate(bytecode, chunks, signingPrivateKey, clientOperator) {
+async function fileCreate(bytecode, signingPrivateKey, clientOperator) {
     const fileCreateTx = new FileCreateTransaction().setKeys([signingPrivateKey]).freezeWith(clientOperator);
     const fileSign = await fileCreateTx.sign(signingPrivateKey);
     const fileSubmit = await fileSign.execute(clientOperator);
@@ -252,7 +251,7 @@ async function fileCreate(bytecode, chunks, signingPrivateKey, clientOperator) {
     const fileAppendTx = new FileAppendTransaction()
         .setFileId(bytecodeFileId)
         .setContents(bytecode)
-        .setMaxChunks(chunks)
+        .setMaxChunks(35)
         .setMaxTransactionFee(new Hbar(2))
         .freezeWith(clientOperator);
     const fileAppendSign = await fileAppendTx.sign(signingPrivateKey);
@@ -331,5 +330,6 @@ export {
     getOperatorAccountBalanceSDK,
     getContractBalanceSDK,
     addHbarTransferSDK,
-    deleteContractSDK
+    deleteContractSDK,
+    fileCreate
 }


### PR DESCRIPTION
Signed-off-by: Greg Scullard <greg@swirldslabs.com>

**Description**:
This PR splits the bytecode upload from contract creation meaning uploaded bytecode can be reused across tests, by reducing the number of files created during e2e tests, we decrease the overall hbar costs of running the tests and allow them to execute faster.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
