### PR TITLE
Refactor of revokeSupplierRole

### DIFF
--- a/contracts/contracts/extensions/ISupplierAdmin.sol
+++ b/contracts/contracts/extensions/ISupplierAdmin.sol
@@ -8,7 +8,6 @@ interface ISupplierAdmin {
     function grantSupplierRole(address supplier, uint256 amount) external virtual;
     function grantUnlimitedSupplierRole(address supplier) external virtual;
     function revokeSupplierRole(address supplier) external virtual; 
-    function revokeUnlimitedSupplierRole(address supplier) external virtual;
     function resetSupplierAllowance(address supplier) external;
     function increaseSupplierAllowance(address supplier, uint256 amount) external; 
     function decreaseSupplierAllowance(address supplier, uint256 amount) external;

--- a/contracts/contracts/extensions/SupplierAdmin.sol
+++ b/contracts/contracts/extensions/SupplierAdmin.sol
@@ -58,17 +58,9 @@ abstract contract SupplierAdmin is ISupplierAdmin, AccessControlUpgradeable, Tok
         onlyRole(ADMIN_SUPPLIER_ROLE) 
     {
         supplierAllowances[supplier] = 0;
-        _revokeRole(SUPPLIER_ROLE, supplier);
-    }
-
-    function revokeUnlimitedSupplierRole(address supplier)
-        external 
-        virtual 
-        onlyRole(ADMIN_SUPPLIER_ROLE) 
-    {
         unlimitedSupplierAllowances[supplier] = false;
         _revokeRole(SUPPLIER_ROLE, supplier);
-    }    
+    }
 
     function resetSupplierAllowance(address supplier) 
         external 

--- a/contracts/scripts/utils.ts
+++ b/contracts/scripts/utils.ts
@@ -39,7 +39,7 @@ export async function deployContractsWithSDK(name:string, symbol:string, decimal
   const tokenOwnerContract = await deployContractSDK(HTSTokenOwner__factory, 10, privateKey, clientSdk);
 
   console.log("Creating token... please wait.");
-  const hederaToken = await createToken(tokenOwnerContract, name,  symbol, decimals, initialSupply, maxSupply, memo, freeze, account!, privateKey!, publicKey!, clientSdk);
+  const hederaToken = await createToken(tokenOwnerContract, name,  symbol, decimals, initialSupply, maxSupply, String(proxyContract), freeze, account!, privateKey!, publicKey!, clientSdk);
 
   console.log("Setting up contract... please wait.");
   parametersContractCall = [tokenOwnerContract!.toSolidityAddress(),TokenId.fromString(hederaToken!.toString()).toSolidityAddress()];    

--- a/contracts/test/supplieradmin.ts
+++ b/contracts/test/supplieradmin.ts
@@ -159,7 +159,7 @@ describe("Revoke unlimited supplier role", function() {
   });
   it("An account with unlimited supplier role, but revoked, can not cash in 100 tokens", async function() {
     let params : any = [AccountId.fromString(hreConfig.accounts[1].account!).toSolidityAddress()];  
-    await contractCall(ContractId.fromString(proxyAddress), 'revokeUnlimitedSupplierRole', params, client, 130000, HederaERC20__factory.abi);
+    await contractCall(ContractId.fromString(proxyAddress), 'revokeSupplierRole', params, client, 130000, HederaERC20__factory.abi);
     const client2 = getClient();
     client2.setOperator(hreConfig.accounts[1].account!, hreConfig.accounts[1].privateKey!);        
     params = [AccountId.fromString(hreConfig.accounts[1].account!).toSolidityAddress()];  


### PR DESCRIPTION
A refactor of revokeSupplierRole function is made. Now, when this function is invoked the SUPPLIER_ROLE is revoked for the specified account, the supplierAllowance is set to 0
and the unlimitedSupplierAllowances is set to false.

You can test the functionality executing this test:
`npx hardhat test --network testnet test/supplieradmin.ts`