### PR TITLE
Fixed circular stringify

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@hashgraph/hethers": "^1.2.2",
     "@hashgraph/sdk": "^2.18.4",
+    "fast-safe-stringify": "^2.1.1",
     "hashconnect": "file:../hashconnect/lib",
     "perf_hooks": "^0.0.1",
     "reflect-metadata": "^0.1.13",

--- a/sdk/src/app/service/log/LogService.ts
+++ b/sdk/src/app/service/log/LogService.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createLogger, LoggerOptions, transports, format } from 'winston';
+import safeStringify from 'fast-safe-stringify';
 import BaseError from '../../../core/error/BaseError.js';
 
 const { Console } = transports;
@@ -26,7 +27,7 @@ export default class LogService {
 					.map((e) => {
 						switch (typeof e) {
 							case 'object':
-								return JSON.stringify(e);
+								return safeStringify(e);
 							default:
 								return e;
 						}


### PR DESCRIPTION
Signed-off-by: Sergio Alba <sergio.alba@io.builders>

**Description**:
- Fixes an issue where the logger would crash if a circular JSON dependency was found in args.
