### PR TITLE
Adding '?? propertyNotFound' in placeholder and label parameters in kyc

### DIFF
--- a/web/src/views/Operations/CheckKyc/index.tsx
+++ b/web/src/views/Operations/CheckKyc/index.tsx
@@ -16,6 +16,7 @@ import { RouterManager } from '../../../Router/RouterManager';
 
 import { KYCRequest } from 'hedera-stable-coin-sdk';
 import { useRefreshCoinInfo } from '../../../hooks/useRefreshCoinInfo';
+import { propertyNotFound } from '../../../constant';
 
 const CheckKycOperation = () => {
 	const {
@@ -84,7 +85,7 @@ const CheckKycOperation = () => {
 						<Stack as='form' spacing={6} maxW='520px'>
 							<InputController
 								rules={{
-									required: t('global:validations.required'),
+									required: t('global:validations.required') ?? propertyNotFound,
 									validate: {
 										validation: (value: string) => {
 											request.targetId = value;
@@ -96,8 +97,8 @@ const CheckKycOperation = () => {
 								isRequired
 								control={control}
 								name='targetAccount'
-								placeholder={t('checkKyc:accountPlaceholder')}
-								label={t('checkKyc:accountLabel')}
+								placeholder={t('checkKyc:accountPlaceholder') ?? propertyNotFound}
+								label={t('checkKyc:accountLabel') ?? propertyNotFound}
 							/>
 						</Stack>
 					</>

--- a/web/src/views/Operations/GrantKyc/index.tsx
+++ b/web/src/views/Operations/GrantKyc/index.tsx
@@ -16,6 +16,7 @@ import { RouterManager } from '../../../Router/RouterManager';
 
 import { KYCRequest } from 'hedera-stable-coin-sdk';
 import { useRefreshCoinInfo } from '../../../hooks/useRefreshCoinInfo';
+import { propertyNotFound } from '../../../constant';
 
 const GrantKycOperation = () => {
 	const {
@@ -83,7 +84,7 @@ const GrantKycOperation = () => {
 						<Stack as='form' spacing={6} maxW='520px'>
 							<InputController
 								rules={{
-									required: t('global:validations.required'),
+									required: t('global:validations.required') ?? propertyNotFound,
 									validate: {
 										validation: (value: string) => {
 											request.targetId = value;
@@ -95,8 +96,8 @@ const GrantKycOperation = () => {
 								isRequired
 								control={control}
 								name='targetAccount'
-								placeholder={t('grantKYC:accountPlaceholder')}
-								label={t('grantKYC:accountLabel')}
+								placeholder={t('grantKYC:accountPlaceholder') ?? propertyNotFound}
+								label={t('grantKYC:accountLabel') ?? propertyNotFound}
 							/>
 						</Stack>
 					</>

--- a/web/src/views/Operations/RevokeKyc/index.tsx
+++ b/web/src/views/Operations/RevokeKyc/index.tsx
@@ -16,6 +16,7 @@ import { RouterManager } from '../../../Router/RouterManager';
 
 import { KYCRequest } from 'hedera-stable-coin-sdk';
 import { useRefreshCoinInfo } from '../../../hooks/useRefreshCoinInfo';
+import { propertyNotFound } from '../../../constant';
 
 const RevokeKycOperation = () => {
 	const {
@@ -83,7 +84,7 @@ const RevokeKycOperation = () => {
 						<Stack as='form' spacing={6} maxW='520px'>
 							<InputController
 								rules={{
-									required: t('global:validations.required'),
+									required: t('global:validations.required') ?? propertyNotFound,
 									validate: {
 										validation: (value: string) => {
 											request.targetId = value;
@@ -95,8 +96,8 @@ const RevokeKycOperation = () => {
 								isRequired
 								control={control}
 								name='targetAccount'
-								placeholder={t('revokeKYC:accountPlaceholder')}
-								label={t('revokeKYC:accountLabel')}
+								placeholder={t('revokeKYC:accountPlaceholder') ?? propertyNotFound}
+								label={t('revokeKYC:accountLabel') ?? propertyNotFound}
 							/>
 						</Stack>
 					</>


### PR DESCRIPTION
In some kyc operations views, some tags have the property:

placeholder={t('checkKyc:accountPlaceholder') or label={t('checkKyc:accountLabel')

which fails in compilation since it must be:

placeholder={t('checkKyc:accountPlaceholder') ?? propertyNotFound}
label={t('checkKyc:accountLabel') ?? propertyNotFound}