### PR TITLE
[BBND-326] Fix Tx results call to RPC when using Metamask

### DIFF
--- a/sdk/example/ts/index.ts
+++ b/sdk/example/ts/index.ts
@@ -9,6 +9,7 @@ import {
 	StableCoin,
 	SupportedWallets,
 } from '@hashgraph/stablecoin-npm-sdk';
+import LogService from '../../app/service/LogService.js';
 
 async function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -33,26 +34,32 @@ const main = async (): Promise<void> => {
 			network: 'testnet',
 			events: {
 				walletInit(data) {
-					console.log('Wallet initialized ', data);
+					LogService.logInfo('Wallet initialized ', data);
 				},
 				walletDisconnect(data) {
-					console.log('Wallet disconnected ', data);
+					LogService.logInfo('Wallet disconnected ', data);
 				},
 				walletConnectionStatusChanged(data) {
-					console.log('Wallet connection changed ', data);
+					LogService.logInfo(
+						'Wallet connection status changed ',
+						data,
+					);
 				},
 				walletPaired(data) {
-					console.log('Wallet paired ', data);
+					LogService.logInfo('Wallet paired ', data);
 					isPaired = true;
 				},
 				walletFound(data) {
-					console.log('Wallet found ', data);
+					LogService.logInfo('Wallet found ', data);
 				},
 			},
 		}),
 	);
 
-	console.log('Supported wallets ', supportedWallets);
+	LogService.logInfo(
+		'Supported wallets: ',
+		JSON.stringify(supportedWallets, null, 2),
+	);
 
 	// Make the connection to one of the supported wallets
 	const connectionData = await Network.connect(
@@ -62,7 +69,7 @@ const main = async (): Promise<void> => {
 		}),
 	);
 
-	console.log('Connection data ', connectionData);
+	LogService.logInfo('Connected to wallet: ', JSON.stringify(connectionData));
 
 	// Create a stablecoin
 	const createRequest = new CreateRequest({
@@ -102,7 +109,7 @@ const main = async (): Promise<void> => {
 	// --------
 	const createdCoin = await StableCoin.create(createRequest);
 
-	console.log('Created: ', createdCoin);
+	LogService.logInfo('Created coin: ', JSON.stringify(createdCoin, null, 2));
 };
 
 try {

--- a/sdk/src/port/out/mirror/MirrorNodeAdapter.ts
+++ b/sdk/src/port/out/mirror/MirrorNodeAdapter.ts
@@ -613,11 +613,11 @@ export class MirrorNodeAdapter {
 		timeout = 30,
 		requestInterval = 3,
 	): Promise<string[] | null> {
-		// if (transactionId.match(REGEX_TRANSACTION)) {
-		transactionId = transactionId
-			.replace('@', '-')
-			.replace(/.([^.]*)$/, '-$1');
-		// }
+		if (transactionId.startsWith('0.')) {
+			transactionId = transactionId
+				.replace('@', '-')
+				.replace(/.([^.]*)$/, '-$1');
+		} // else starts with 0x and do nothing
 		const url = `${this.mirrorNodeConfig.baseUrl}contracts/results/${transactionId}`;
 		let call_OK = false;
 		const results: string[] = [];


### PR DESCRIPTION
## Description

When using Metamask the call to […]/contracts/results/${TxID} is wrong.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue) 🐞
- [ ] New feature (non-breaking change which adds functionality) ✨
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 💥
- [ ] This change requires a documentation update 📖

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. 🧪

- [X] Local Tests (npm run test)
- [X] Manually (example: cli with wizard or web using web interface)
- [ ] Local Github Actions (act pull_request)

**Test Configuration**:

- Node version (latest LTS):
  - [X] 20

### Test Results (if any)

## Checklist:

- **Style Guidelines** (My code follows the style guidelines of this project) ✅
- **Self-Review** (I have performed a self-review of my own code) 👀
- **Code Comments** (I have commented my code, particularly in hard-to-understand areas) 💬
- **Documentation Updates** (I have made corresponding changes to the documentation) 📚
- **Warning-Free Changes** (My changes generate no new warnings) ⚠️
- **Effective Tests** (I have added tests that prove my fix is effective or that my feature works) ✔️
- **Local Test Pass** (New and existing unit tests pass locally with my changes) ✅
- **Dependency Updates** (Any dependent changes have been merged and published in downstream modules) 🔄
- **Spellcheck** (I have checked my code and corrected any misspellings) 📝
