### PR TITLE
fix: RESD-194 fix publishing in stablecoin studio

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Change references to repo
         run: |
           ls -alF
-          ../changeProjectsReferencesToRepo.sh
+          ./changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -112,7 +112,7 @@ jobs:
       - name: Change references to repo
         run: | 
           ls -alF
-          ../changeProjectsReferencesToRepo.sh
+          ./changeProjectsReferencesToRepo.sh
         
         
 
@@ -174,7 +174,7 @@ jobs:
       - name: Change references to repo
         run: |
           ls -alF
-          ../changeProjectsReferencesToRepo.sh
+          ./changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,8 +9,8 @@ on:
       dry_run:
         description: "Run npm publish with dry-run flag"
         required: false
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
 
 defaults:
   run:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Change references to repo
         run: |
-          ls -alF
-          changeProjectsReferencesToRepo.sh
+          ./changeProjectsReferencesToRepo.sh
+        working-directory: ${{ github.workspace }}
 
       - name: Install Contracts
         run: npm ci
@@ -110,9 +110,9 @@ jobs:
         working-directory: sdk
 
       - name: Change references to repo
-        run: | 
-          ls -alF
-          changeProjectsReferencesToRepo.sh
+        run: |
+          ./changeProjectsReferencesToRepo.sh
+        working-directory: ${{ github.workspace }}
         
         
 
@@ -173,8 +173,8 @@ jobs:
 
       - name: Change references to repo
         run: |
-          ls -alF
-          changeProjectsReferencesToRepo.sh
+          ./changeProjectsReferencesToRepo.sh
+        working-directory: ${{ github.workspace }}
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,9 +46,6 @@ jobs:
           node-version: '20'
           token: ${{ secrets.NPM_TOKEN }}
 
-      - name: Install bash
-        run: apk add --no-cache bash
-
       - name: Create file .npmrc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -100,9 +97,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: '0'
-
-      - name: Install bash
-        run: apk add --no-cache bash
 
       - name: Setup NPM
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
@@ -164,9 +158,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: '0'
-
-      - name: Install bash
-        run: apk add --no-cache bash
 
       - name: Setup NPM
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Change references to repo
         run: |
           ls -alF
-          ./changeProjectsReferencesToRepo.sh
+          changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -112,7 +112,7 @@ jobs:
       - name: Change references to repo
         run: | 
           ls -alF
-          ./changeProjectsReferencesToRepo.sh
+          changeProjectsReferencesToRepo.sh
         
         
 
@@ -174,7 +174,7 @@ jobs:
       - name: Change references to repo
         run: |
           ls -alF
-          ./changeProjectsReferencesToRepo.sh
+          changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,9 @@ jobs:
         working-directory: contracts
 
       - name: Change references to repo
-        run: ../changeProjectsReferencesToRepo.sh
+        run: |
+          ls -alF
+          ../changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -108,7 +110,11 @@ jobs:
         working-directory: sdk
 
       - name: Change references to repo
-        run: ../changeProjectsReferencesToRepo.sh
+        run: | 
+          ls -alF
+          ../changeProjectsReferencesToRepo.sh
+        
+        
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -166,7 +172,9 @@ jobs:
         working-directory: cli
 
       - name: Change references to repo
-        run: ../changeProjectsReferencesToRepo.sh
+        run: |
+          ls -alF
+          ../changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Change references to repo
         run:  |
-          chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
@@ -119,7 +118,6 @@ jobs:
 
       - name: Change references to repo
         run:  |
-          chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
@@ -182,7 +180,6 @@ jobs:
 
       - name: Change references to repo
         run: |
-          chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,10 @@ on:
         type: boolean
         default: false
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,10 +12,6 @@ on:
         type: boolean
         default: false
 
-defaults:
-  run:
-    shell: bash
-
 permissions:
   contents: read
 
@@ -46,6 +42,9 @@ jobs:
           node-version: '20'
           token: ${{ secrets.NPM_TOKEN }}
 
+      - name: Install bash
+        run: apk add --no-cache bash
+
       - name: Create file .npmrc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -55,16 +54,19 @@ jobs:
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
         working-directory: contracts
+        shell: bash
 
       - name: Change references to repo
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+        shell: bash
 
       - name: Install Contracts
         run: npm ci
         working-directory: contracts
+        shell: bash
 
       - name: Publish contracts
         env:
@@ -76,6 +78,7 @@ jobs:
           else
             npm run publish:contracts --access=public
           fi
+        shell: bash
 
   sdk:
     # needs: contracts
@@ -98,6 +101,9 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: '0'
 
+      - name: Install bash
+        run: apk add --no-cache bash
+
       - name: Setup NPM
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
@@ -113,12 +119,14 @@ jobs:
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
         working-directory: sdk
+        shell: bash
 
       - name: Change references to repo
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+        shell: bash
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -137,6 +145,7 @@ jobs:
             npm run publish:sdk --access=public
           fi
         working-directory: sdk
+        shell: bash
 
   cli:
     # needs: sdk
@@ -159,6 +168,9 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: '0'
 
+      - name: Install bash
+        run: apk add --no-cache bash
+
       - name: Setup NPM
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
@@ -174,12 +186,14 @@ jobs:
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
         working-directory: cli
+        shell: bash
 
       - name: Change references to repo
         run: |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+        shell: bash
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -198,3 +212,4 @@ jobs:
             npm run publish:cli --access=public
           fi
         working-directory: cli
+        shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
       - published
   workflow_dispatch:
     inputs:
-      dry_run:
+      dry-run-enabled:
         description: "Run npm publish with dry-run flag"
         required: false
         type: boolean
@@ -58,7 +58,6 @@ jobs:
 
       - name: Change references to repo
         run:  |
-          ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
@@ -69,7 +68,7 @@ jobs:
       - name: Publish contracts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          DRY_RUN: ${{ inputs.dry-run-enabled }}
         run: |
           echo "DRY_RUN is set to: '${DRY_RUN}'"
           
@@ -120,7 +119,6 @@ jobs:
 
       - name: Change references to repo
         run:  |
-          ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
@@ -133,7 +131,7 @@ jobs:
       - name: Publish sdk package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          DRY_RUN: ${{ inputs.dry-run-enabled }}
         run: |
           echo "DRY_RUN is set to: '${DRY_RUN}'"
           
@@ -184,7 +182,6 @@ jobs:
 
       - name: Change references to repo
         run: |
-          ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
@@ -197,7 +194,7 @@ jobs:
       - name: Publish cli package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          DRY_RUN: ${{ inputs.dry-run-enabled }}
         run: |
           echo "DRY_RUN is set to: '${DRY_RUN}'"
           

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,9 +53,7 @@ jobs:
         working-directory: contracts
 
       - name: Change references to repo
-        run: |
-          changeProjectsReferencesToRepo.sh
-        working-directory: ${{ github.workspace }}
+        run: ${{ github.workspace }}/changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -110,11 +108,7 @@ jobs:
         working-directory: sdk
 
       - name: Change references to repo
-        run: |
-          changeProjectsReferencesToRepo.sh
-        working-directory: ${{ github.workspace }}
-        
-        
+        run: ${{ github.workspace }}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -172,9 +166,7 @@ jobs:
         working-directory: cli
 
       - name: Change references to repo
-        run: |
-          changeProjectsReferencesToRepo.sh
-        working-directory: ${{ github.workspace }}
+        run: ${{ github.workspace }}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Change references to repo
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
-          chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
+          chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
@@ -113,7 +113,7 @@ jobs:
       - name: Change references to repo
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
-          chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
+          chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
@@ -174,7 +174,7 @@ jobs:
       - name: Change references to repo
         run: |
           ls -alF ${GITHUB_WORKSPACE}
-          chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
+          chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -80,7 +80,7 @@ jobs:
             ARGS="--access=public"
           fi
 
-          npm run publish:contracts "${ARGS}"
+          npm run publish:contracts -- "${ARGS}"
         working-directory: ${{ github.workspace }}
 
   sdk:
@@ -146,7 +146,7 @@ jobs:
             ARGS="--access=public"
           fi
 
-          npm run publish:sdk "${ARGS}"
+          npm run publish:sdk -- "${ARGS}"
         working-directory: ${{ github.workspace }}
 
   cli:
@@ -212,5 +212,5 @@ jobs:
             ARGS="--access=public"
           fi
 
-          npm run publish:cli "${ARGS}"
+          npm run publish:cli -- "${ARGS}"
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,11 +73,13 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [ "${DRY_RUN}" == "true" ]; then
-            npm run publish:contracts --access=public --dry-run
-          else
-            npm run publish:contracts --access=public
-          fi
+          bash -c '
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              npm run publish:cli --access=public --dry-run
+            else
+              npm run publish:cli --access=public
+            fi
+          '
         shell: bash
 
   sdk:
@@ -139,11 +141,13 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [ "${DRY_RUN}" == "true" ]; then
-            npm run publish:sdk --access=public --dry-run
-          else
-            npm run publish:sdk --access=public
-          fi
+          bash -c '
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              npm run publish:cli --access=public --dry-run
+            else
+              npm run publish:cli --access=public
+            fi
+          '
         working-directory: sdk
         shell: bash
 
@@ -206,10 +210,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [ "${DRY_RUN}" == "true" ]; then
-            npm run publish:cli --access=public --dry-run
-          else
-            npm run publish:cli --access=public
-          fi
+          bash -c '
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              npm run publish:cli --access=public --dry-run
+            else
+              npm run publish:cli --access=public
+            fi
+          '
         working-directory: cli
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,7 +56,7 @@ jobs:
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
-          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh/changeProjectsReferencesToRepo.sh
+          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -114,7 +114,7 @@ jobs:
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
-          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh/changeProjectsReferencesToRepo.sh
+          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,11 +6,11 @@ on:
       - published
   workflow_dispatch:
     inputs:
-      dry-run:
+      dry_run:
         description: "Run npm publish with dry-run flag"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'false'
 
 permissions:
   contents: read
@@ -71,9 +71,9 @@ jobs:
       - name: Publish contracts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry-run }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [[ "$DRY_RUN" == "true" ]]; then
+          if [[ "${DRY_RUN}" == "true" ]]; then
             npm run publish:contracts --access=public --dry-run
           else
             npm run publish:contracts --access=public
@@ -137,9 +137,9 @@ jobs:
       - name: Publish sdk package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry-run }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [[ "$DRY_RUN" == "true" ]]; then
+          if [[ "${DRY_RUN}" == "true" ]]; then
             npm run publish:sdk --access=public --dry-run
           else
             npm run publish:sdk --access=public
@@ -204,9 +204,9 @@ jobs:
       - name: Publish cli package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry-run }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [[ "$DRY_RUN" == "true" ]]; then
+          if [[ "${DRY_RUN}" == "true" ]]; then
             npm run publish:cli --access=public --dry-run
           else
             npm run publish:cli --access=public

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -71,11 +71,17 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-            if [[ "${DRY_RUN}" == "true" ]]; then
-              npm run publish:cli --access=public --dry-run
-            else
-              npm run publish:cli --access=public
-            fi
+          echo "DRY_RUN is set to: '${DRY_RUN}'"
+
+          ARGS=""
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            ARGS="--access=public --dry-run"
+          else
+            ARGS="--access=public"
+          fi
+
+          npm run publish "${ARGS}"
+        working-directory: contracts
 
   sdk:
     # needs: contracts
@@ -131,11 +137,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-            if [[ "${DRY_RUN}" == "true" ]]; then
-              npm run publish:cli --access=public --dry-run
-            else
-              npm run publish:cli --access=public
-            fi
+          echo "DRY_RUN is set to: '${DRY_RUN}'"
+
+          ARGS=""
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            ARGS="--access=public --dry-run"
+          else
+            ARGS="--access=public"
+          fi
+
+          npm run publish "${ARGS}"
         working-directory: sdk
 
   cli:
@@ -193,10 +204,13 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           echo "DRY_RUN is set to: '${DRY_RUN}'"
-          
+          ARGS=""
+
           if [[ "${DRY_RUN}" == "true" ]]; then
-              npm run publish:cli --access=public --dry-run
-            else
-              npm run publish:cli --access=public
-            fi
+            ARGS="--access=public --dry-run"
+          else
+            ARGS="--access=public"
+          fi
+
+          npm run publish "${ARGS}"
         working-directory: cli

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -80,8 +80,8 @@ jobs:
             ARGS="--access=public"
           fi
 
-          npm run publish "${ARGS}"
-        working-directory: contracts
+          npm run publish:contracts "${ARGS}"
+        working-directory: ${{ github.workspace }}
 
   sdk:
     # needs: contracts
@@ -146,8 +146,8 @@ jobs:
             ARGS="--access=public"
           fi
 
-          npm run publish "${ARGS}"
-        working-directory: sdk
+          npm run publish:sdk "${ARGS}"
+        working-directory: ${{ github.workspace }}
 
   cli:
     # needs: sdk
@@ -212,5 +212,5 @@ jobs:
             ARGS="--access=public"
           fi
 
-          npm run publish "${ARGS}"
-        working-directory: cli
+          npm run publish:cli "${ARGS}"
+        working-directory: ${{ github.workspace }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -137,13 +137,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          bash -c '
             if [[ "${DRY_RUN}" == "true" ]]; then
               npm run publish:cli --access=public --dry-run
             else
               npm run publish:cli --access=public
             fi
-          '
         working-directory: sdk
 
   cli:
@@ -203,11 +201,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          bash -c '
             if [[ "${DRY_RUN}" == "true" ]]; then
               npm run publish:cli --access=public --dry-run
             else
               npm run publish:cli --access=public
             fi
-          '
         working-directory: cli

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Change references to repo
         run:  |
-          ls -alF
+          ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
           {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh/changeProjectsReferencesToRepo.sh
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Change references to repo
         run:  |
-          ls -alF
+          ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
           {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh/changeProjectsReferencesToRepo.sh
 
@@ -173,7 +173,7 @@ jobs:
 
       - name: Change references to repo
         run: |
-          ls -alF
+          ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
           {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Change references to repo
         run: |
-          ./changeProjectsReferencesToRepo.sh
+          changeProjectsReferencesToRepo.sh
         working-directory: ${{ github.workspace }}
 
       - name: Install Contracts
@@ -111,7 +111,7 @@ jobs:
 
       - name: Change references to repo
         run: |
-          ./changeProjectsReferencesToRepo.sh
+          changeProjectsReferencesToRepo.sh
         working-directory: ${{ github.workspace }}
         
         
@@ -173,7 +173,7 @@ jobs:
 
       - name: Change references to repo
         run: |
-          ./changeProjectsReferencesToRepo.sh
+          changeProjectsReferencesToRepo.sh
         working-directory: ${{ github.workspace }}
 
       # * Prepare other modules

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -192,7 +192,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-            if [[ "${DRY_RUN}" == "true" ]]; then
+          echo "DRY_RUN is set to: '${DRY_RUN}'"
+          
+          if [[ "${DRY_RUN}" == "true" ]]; then
               npm run publish:cli --access=public --dry-run
             else
               npm run publish:cli --access=public

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,10 @@ on:
         type: string
         default: 'false'
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: read
 
@@ -19,7 +23,7 @@ jobs:
   contracts:
     runs-on: token-studio-linux-medium
     container:
-      image: node:20.17.0-alpine3.20 # Using alpine for a smaller image
+      image: node@sha256:sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
     permissions:
       contents: read
 
@@ -54,39 +58,33 @@ jobs:
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
         working-directory: contracts
-        shell: bash
 
       - name: Change references to repo
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
-        shell: bash
 
       - name: Install Contracts
         run: npm ci
         working-directory: contracts
-        shell: bash
 
       - name: Publish contracts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          bash -c '
             if [[ "${DRY_RUN}" == "true" ]]; then
               npm run publish:cli --access=public --dry-run
             else
               npm run publish:cli --access=public
             fi
-          '
-        shell: bash
 
   sdk:
     # needs: contracts
     runs-on: token-studio-linux-medium
     container:
-      image: node:20.17.0-alpine3.20 # Using alpine for a smaller image
+      image: node@sha256:sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
     permissions:
       contents: read
 
@@ -121,14 +119,12 @@ jobs:
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
         working-directory: sdk
-        shell: bash
 
       - name: Change references to repo
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
-        shell: bash
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -149,13 +145,12 @@ jobs:
             fi
           '
         working-directory: sdk
-        shell: bash
 
   cli:
     # needs: sdk
     runs-on: token-studio-linux-medium
     container:
-      image: node:20.17.0-alpine3.20 # Using alpine for a smaller image
+      image: node@sha256:sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
     permissions:
       contents: read
 
@@ -190,14 +185,12 @@ jobs:
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
         working-directory: cli
-        shell: bash
 
       - name: Change references to repo
         run: |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
           ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
-        shell: bash
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -218,4 +211,3 @@ jobs:
             fi
           '
         working-directory: cli
-        shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [[ "${DRY_RUN}" == "true" ]]; then
+          if [ "${DRY_RUN}" == "true" ]; then
             npm run publish:contracts --access=public --dry-run
           else
             npm run publish:contracts --access=public
@@ -139,7 +139,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [[ "${DRY_RUN}" == "true" ]]; then
+          if [ "${DRY_RUN}" == "true" ]; then
             npm run publish:sdk --access=public --dry-run
           else
             npm run publish:sdk --access=public
@@ -206,7 +206,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [[ "${DRY_RUN}" == "true" ]]; then
+          if [ "${DRY_RUN}" == "true" ]; then
             npm run publish:cli --access=public --dry-run
           else
             npm run publish:cli --access=public

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,7 @@ jobs:
         working-directory: contracts
 
       - name: Change references to repo
-        run: ${{ github.workspace }}/changeProjectsReferencesToRepo.sh
+        run: chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh; ls -alF; ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -108,7 +108,7 @@ jobs:
         working-directory: sdk
 
       - name: Change references to repo
-        run: ${{ github.workspace }}/changeProjectsReferencesToRepo.sh
+        run: chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh; ls -alF; ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -166,7 +166,7 @@ jobs:
         working-directory: cli
 
       - name: Change references to repo
-        run: ${{ github.workspace }}/changeProjectsReferencesToRepo.sh
+        run: ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
   contracts:
     runs-on: token-studio-linux-medium
     container:
-      image: node@sha256:sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
+      image: node@sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
     permissions:
       contents: read
 
@@ -84,7 +84,7 @@ jobs:
     # needs: contracts
     runs-on: token-studio-linux-medium
     container:
-      image: node@sha256:sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
+      image: node@sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
     permissions:
       contents: read
 
@@ -148,7 +148,7 @@ jobs:
     # needs: sdk
     runs-on: token-studio-linux-medium
     container:
-      image: node@sha256:sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
+      image: node@sha256:db5dd2f30cb82a8bdbd16acd4a8f3f2789f5b24f6ce43f98aa041be848c82e45 # node:20.17.0-bookworm
     permissions:
       contents: read
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,10 @@ jobs:
         working-directory: contracts
 
       - name: Change references to repo
-        run: chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh; ls -alF; ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+        run:  |
+          ls -alF
+          chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
+          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh/changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -108,7 +111,10 @@ jobs:
         working-directory: sdk
 
       - name: Change references to repo
-        run: chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh; ls -alF; ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+        run:  |
+          ls -alF
+          chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
+          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -166,7 +172,10 @@ jobs:
         working-directory: cli
 
       - name: Change references to repo
-        run: ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+        run: |
+          ls -alF
+          chmod +x ${GITHUB_WORKSPACE}/changeProjectsRefrencesToRepo.sh
+          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,7 @@ jobs:
         working-directory: contracts
 
       - name: Change references to repo
-        run: ./changeProjectsReferencesToRepo.sh
+        run: ../changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -108,7 +108,7 @@ jobs:
         working-directory: sdk
 
       - name: Change references to repo
-        run: ./changeProjectsReferencesToRepo.sh
+        run: ../changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -166,7 +166,7 @@ jobs:
         working-directory: cli
 
       - name: Change references to repo
-        run: ./changeProjectsReferencesToRepo.sh
+        run: ../changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -72,15 +72,13 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           echo "DRY_RUN is set to: '${DRY_RUN}'"
-
-          ARGS=""
+          
+          ARGS=("--access=public")
           if [[ "${DRY_RUN}" == "true" ]]; then
-            ARGS="--access=public --dry-run"
-          else
-            ARGS="--access=public"
+            ARGS+=("--dry-run")
           fi
 
-          npm run publish:contracts -- "${ARGS}"
+          npm run publish:contracts -- "${ARGS[@]}"
         working-directory: ${{ github.workspace }}
 
   sdk:
@@ -138,15 +136,13 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           echo "DRY_RUN is set to: '${DRY_RUN}'"
-
-          ARGS=""
+          
+          ARGS=("--access=public")
           if [[ "${DRY_RUN}" == "true" ]]; then
-            ARGS="--access=public --dry-run"
-          else
-            ARGS="--access=public"
+            ARGS+=("--dry-run")
           fi
 
-          npm run publish:sdk -- "${ARGS}"
+          npm run publish:sdk -- "${ARGS[@]}"
         working-directory: ${{ github.workspace }}
 
   cli:
@@ -204,13 +200,11 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           echo "DRY_RUN is set to: '${DRY_RUN}'"
-          ARGS=""
-
+          
+          ARGS=("--access=public")
           if [[ "${DRY_RUN}" == "true" ]]; then
-            ARGS="--access=public --dry-run"
-          else
-            ARGS="--access=public"
+            ARGS+=("--dry-run")
           fi
 
-          npm run publish:cli -- "${ARGS}"
+          npm run publish:cli -- "${ARGS[@]}"
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,7 +56,7 @@ jobs:
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
-          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+          ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       - name: Install Contracts
         run: npm ci
@@ -114,7 +114,7 @@ jobs:
         run:  |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
-          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+          ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK
@@ -175,7 +175,7 @@ jobs:
         run: |
           ls -alF ${GITHUB_WORKSPACE}
           chmod +x ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
-          {GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
+          ${GITHUB_WORKSPACE}/changeProjectsReferencesToRepo.sh
 
       # * Prepare other modules
       - name: Install and build Contracts and SDK

--- a/cli/package.json
+++ b/cli/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^18.11.18",
     "@types/ora": "^3.2.0",
     "@types/shelljs": "^0.8.15",
-    "@typescript-eslint/eslint-plugin": "^5.48.2",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.48.2",
     "cross-env": "^7.0.3",
     "eslint": "^8.32.0",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -76,7 +76,7 @@
         "@primitivefi/hardhat-dodoc": "^0.2.3",
         "@typechain/ethers-v5": "10.1.0",
         "@typechain/hardhat": "6.1.3",
-        "@typescript-eslint/eslint-plugin": "^5.38.1",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.38.1",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-stable-coin",
-  "version": "1.27.6",
+  "version": "1.27.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-stable-coin",
-      "version": "1.27.6",
+      "version": "1.27.7",
       "license": "Apache-2.0",
       "workspaces": [
         "backend",
@@ -28,7 +28,7 @@
     },
     "backend": {
       "name": "@hashgraph/stablecoin-npm-backend",
-      "version": "1.27.6",
+      "version": "1.27.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/sdk": "2.51.0",
@@ -92,7 +92,7 @@
     },
     "cli": {
       "name": "@hashgraph/stablecoin-npm-cli",
-      "version": "1.27.6",
+      "version": "1.27.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/stablecoin-npm-sdk": "*",
@@ -125,7 +125,7 @@
         "@types/node": "^18.11.18",
         "@types/ora": "^3.2.0",
         "@types/shelljs": "^0.8.15",
-        "@typescript-eslint/eslint-plugin": "^5.48.2",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.48.2",
         "cross-env": "^7.0.3",
         "eslint": "^8.32.0",
@@ -267,7 +267,7 @@
     },
     "contracts": {
       "name": "@hashgraph/stablecoin-npm-contracts",
-      "version": "1.27.6",
+      "version": "1.27.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@chainlink/contracts": "^0.5.1",
@@ -283,7 +283,7 @@
         "@primitivefi/hardhat-dodoc": "^0.2.3",
         "@typechain/ethers-v5": "10.1.0",
         "@typechain/hardhat": "6.1.3",
-        "@typescript-eslint/eslint-plugin": "^5.38.1",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.38.1",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
@@ -44465,7 +44465,7 @@
     },
     "sdk": {
       "name": "@hashgraph/stablecoin-npm-sdk",
-      "version": "1.27.6",
+      "version": "1.27.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/cryptography": "1.4.3",
@@ -44502,7 +44502,7 @@
         "@types/jest": "^29.2.6",
         "@types/node": "^18.11.18",
         "@types/uuid": "^9.0.0 ",
-        "@typescript-eslint/eslint-plugin": "^5.48.2",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.48.2",
         "axios": "^ 1.2.3",
         "babel-jest": "^29.3.1 ",
@@ -45201,7 +45201,7 @@
     },
     "web": {
       "name": "@hashgraph/stablecoin-dapp",
-      "version": "1.27.6",
+      "version": "1.27.7",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.17",
         "@chakra-ui/react": "~2.6.1",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -26,7 +26,7 @@
 		"@types/jest": "^29.2.6",
 		"@types/node": "^18.11.18",
 		"@types/uuid": "^9.0.0 ",
-		"@typescript-eslint/eslint-plugin": "^5.48.2",
+		"@typescript-eslint/eslint-plugin": "^5.62.0",
 		"@typescript-eslint/parser": "^5.48.2",
 		"axios": "^ 1.2.3",
 		"babel-jest": "^29.3.1 ",


### PR DESCRIPTION
**Description**:

- Changes the node image to use bookworm instead of alpine.
- Updates `@typescript-eslint/eslint-plugin` version
- Changes argument setup for publish args
- Ensures correct publish script is used for each workspace
- Uses the bash shell by default
- corrects calls to changeProjectsReferencesToRepo.sh to use ${{ github.workspace }}

**Related issue(s)**:

Fixes #1259 
