### PR TITLE
fix: ensure we are generating .npmrc 

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,8 +50,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "@hashgraph:registry=https://registry.npmjs.org/" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+          cat << 'EOF' > .npmrc
+          //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+          EOF
         working-directory: contracts
 
       - name: Change references to repo
@@ -108,8 +109,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "@hashgraph:registry=https://registry.npmjs.org/" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+          cat << 'EOF' > .npmrc
+          //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+          EOF
         working-directory: sdk
 
       - name: Change references to repo
@@ -168,8 +170,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "@hashgraph:registry=https://registry.npmjs.org/" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+          cat << 'EOF' > .npmrc
+          //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+          EOF
         working-directory: cli
 
       - name: Change references to repo

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,6 @@ jobs:
           cat << 'EOF' > .npmrc
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
-        working-directory: contracts
 
       - name: Change references to repo
         run:  |
@@ -76,7 +75,6 @@ jobs:
           fi
 
           npm run publish:contracts -- "${ARGS[@]}"
-        working-directory: ${{ github.workspace }}
 
   sdk:
     # needs: contracts
@@ -112,7 +110,6 @@ jobs:
           cat << 'EOF' > .npmrc
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
-        working-directory: sdk
 
       - name: Change references to repo
         run:  |
@@ -137,7 +134,6 @@ jobs:
           fi
 
           npm run publish:sdk -- "${ARGS[@]}"
-        working-directory: ${{ github.workspace }}
 
   cli:
     # needs: sdk
@@ -173,7 +169,6 @@ jobs:
           cat << 'EOF' > .npmrc
           //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
-        working-directory: cli
 
       - name: Change references to repo
         run: |
@@ -198,4 +193,3 @@ jobs:
           fi
 
           npm run publish:cli -- "${ARGS[@]}"
-        working-directory: ${{ github.workspace }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -174,7 +174,6 @@ jobs:
         run: |
           cat << 'EOF' > .npmrc
           @hashgraph:registry=https://registry.npmjs.org/
-          //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           EOF
         working-directory: cli
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,10 +50,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          cat << 'EOF' > .npmrc
-          @hashgraph:registry=https://registry.npmjs.org/
-          //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
-          EOF
+          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
         working-directory: contracts
 
       - name: Change references to repo
@@ -110,10 +107,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          cat << 'EOF' > .npmrc
-          @hashgraph:registry=https://registry.npmjs.org/
-          //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
-          EOF
+          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
         working-directory: sdk
 
       - name: Change references to repo
@@ -172,9 +166,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          cat << 'EOF' > .npmrc
-          @hashgraph:registry=https://registry.npmjs.org/
-          EOF
+          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
         working-directory: cli
 
       - name: Change references to repo

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
+          echo "@hashgraph:registry=https://registry.npmjs.org/" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
         working-directory: contracts
 
       - name: Change references to repo
@@ -107,7 +108,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
+          echo "@hashgraph:registry=https://registry.npmjs.org/" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
         working-directory: sdk
 
       - name: Change references to repo
@@ -166,7 +168,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
+          echo "@hashgraph:registry=https://registry.npmjs.org/" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
         working-directory: cli
 
       - name: Change references to repo


### PR DESCRIPTION
**Description**:

change how we are generating `.npmrc` so that it is at the root directory (where npm publish is running from)

**Related issue(s)**:

Fixes #1267

**Notes for reviewer**:

Dry-run: https://github.com/hashgraph/stablecoin-studio/actions/runs/14625351535/job/41035416381
Real publish: https://github.com/hashgraph/stablecoin-studio/actions/runs/14625419983

**Checklist**

- [x] Tested (unit, integration, etc.)
