### PR TITLE
Change scripts to create multisig account and to associate a token to a multisig account for only using ECDSA accounts

### DIFF
--- a/packages/sdk/scripts/AssociateToken.ts
+++ b/packages/sdk/scripts/AssociateToken.ts
@@ -40,8 +40,8 @@ import {
 } from '@hiero-ledger/sdk';
 
 // Multisig account keys
-const ED25519_PRIVATE_KEY = '';
-const ECDSA_PRIVATE_KEY   = '';
+const ECDSA_1_PRIVATE_KEY = '';
+const ECDSA_2_PRIVATE_KEY = '';
 
 // The multisig account to associate the token to
 const MULTISIG_ACCOUNT_ID = '';
@@ -52,12 +52,12 @@ const TOKEN_ID = '';
 // Fee payer — single ECDSA account with funds
 const FEE_PAYER = {
 	id: '',
-	privateKey: ECDSA_PRIVATE_KEY,
+	privateKey: '',
 };
 
 async function associateToken(): Promise<void> {
-	const ed25519Key = PrivateKey.fromStringED25519(ED25519_PRIVATE_KEY);
-	const ecdsaKey   = PrivateKey.fromStringECDSA(ECDSA_PRIVATE_KEY);
+	const ecdsaKey1 = PrivateKey.fromStringECDSA(ECDSA_1_PRIVATE_KEY);
+	const ecdsaKey2 = PrivateKey.fromStringECDSA(ECDSA_2_PRIVATE_KEY);
 
 	const client = Client.forTestnet().setOperator(
 		AccountId.fromString(FEE_PAYER.id),
@@ -70,7 +70,7 @@ async function associateToken(): Promise<void> {
 		.freezeWith(client);
 
 	// Both keys of the KeyList must sign
-	const signedTx = await (await tx.sign(ed25519Key)).sign(ecdsaKey);
+	const signedTx = await (await tx.sign(ecdsaKey1)).sign(ecdsaKey2);
 
 	const response = await signedTx.execute(client);
 	const receipt  = await response.getReceipt(client);

--- a/packages/sdk/scripts/CreateMultisigAccount.ts
+++ b/packages/sdk/scripts/CreateMultisigAccount.ts
@@ -38,25 +38,25 @@ import {
 	PrivateKey,
 } from '@hiero-ledger/sdk';
 
-// Clave privada ED25519 de la cuenta 0.0.1579
-const Multisig_ED25519_privateKey = 'e8e993b064ba3d8209a40526513574f043d5af0f900764f35fc92c9a9198deb2';
+// ECDSA private key of account 1
+const Multisig_ECDSA_1_privateKey = '';
 
-// Clave privada ECDSA de la cuenta 0.0.1653
-const Multisig_ECDSA_privateKey = '3bb707249245cfb5090cfa49d598ad43eee5a266a91585f5cddb063ed525e491';
+// ECDSA private key of account 2
+const Multisig_ECDSA_2_privateKey = '';
 
-// Cuenta pagadora (fee payer): debe tener fondos en testnet
+// Payer account (fee payer): It must have funds in the testnet
 const deployingAccount = {
-	id: '0.0.1653',
-	ECDSA_privateKey: '3bb707249245cfb5090cfa49d598ad43eee5a266a91585f5cddb063ed525e491',
+	id: '',
+	ECDSA_privateKey: '',
 };
 
 async function createMultisigAccount(): Promise<void> {
-	const ed25519Key = PrivateKey.fromStringED25519(Multisig_ED25519_privateKey);
-	const ecdsaKey   = PrivateKey.fromStringECDSA(Multisig_ECDSA_privateKey);
+	const ecdsaKey1 = PrivateKey.fromStringECDSA(Multisig_ECDSA_1_privateKey);
+	const ecdsaKey2 = PrivateKey.fromStringECDSA(Multisig_ECDSA_2_privateKey);
 	const feePayerKey = PrivateKey.fromStringECDSA(deployingAccount.ECDSA_privateKey);
 
-	// 2-of-2 KeyList: both ED25519 and ECDSA must sign
-	const keyList = new KeyList([ed25519Key.publicKey, ecdsaKey.publicKey], 2);
+	// 2-of-2 KeyList: both ECDSA keys must sign
+	const keyList = new KeyList([ecdsaKey1.publicKey, ecdsaKey2.publicKey], 2);
 
 	const client = Client.forTestnet().setOperator(
 		AccountId.fromString(deployingAccount.id),
@@ -76,7 +76,6 @@ async function createMultisigAccount(): Promise<void> {
 	}
 
 	console.log(`Multisig account created: ${newAccountId.toString()}`);
-	console.log(`KeyList: ED25519 (0.0.1579) + ECDSA (0.0.1653), threshold 2-of-2`);
 }
 
 createMultisigAccount()


### PR DESCRIPTION
In order to properly test it, the reviewer should create a multisig account using two ECDSA keys and complete an operation over a stablecoin using this multisig account. Therefore, the review should sign the transaction twice, one signature by every ECDSA key.
