### PR TITLE
feat: fix esm exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage/
 
 # Transpiled files
 build/
+**/dist/
 
 # IDE configurations
 .vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@commitlint/config-conventional": "19.8.0",
         "concurrently": "7.6.0",
         "dotenv": "16.4.7",
-        "rimraf": "4.4.1"
+        "rimraf": "4.4.1",
+        "typescript": "^5.1.6"
       }
     },
     "apps/backend": {
@@ -150,6 +151,20 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "apps/backend/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "apps/cli": {
@@ -13088,6 +13103,448 @@
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -19629,6 +20086,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/@reown/appkit-adapter-ethers/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@reown/appkit-adapter-ethers/node_modules/unstorage": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
@@ -20191,6 +20663,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@reown/appkit-core/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@reown/appkit-core/node_modules/unstorage": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
@@ -20748,6 +21235,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@reown/walletkit/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@reown/walletkit/node_modules/unstorage": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
@@ -20950,6 +21452,356 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -22658,6 +23510,278 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@swc/core": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.26.tgz",
+      "integrity": "sha512-tglZGyx8N5PC+x1Nd/JrZxqpqlcZoSuG9gTDKO6AuFToFiVB3uS8HvbKFuO7g3lJzvFf9riAb94xs9HU2UhAHQ==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.26",
+        "@swc/core-darwin-x64": "1.15.26",
+        "@swc/core-linux-arm-gnueabihf": "1.15.26",
+        "@swc/core-linux-arm64-gnu": "1.15.26",
+        "@swc/core-linux-arm64-musl": "1.15.26",
+        "@swc/core-linux-ppc64-gnu": "1.15.26",
+        "@swc/core-linux-s390x-gnu": "1.15.26",
+        "@swc/core-linux-x64-gnu": "1.15.26",
+        "@swc/core-linux-x64-musl": "1.15.26",
+        "@swc/core-win32-arm64-msvc": "1.15.26",
+        "@swc/core-win32-ia32-msvc": "1.15.26",
+        "@swc/core-win32-x64-msvc": "1.15.26"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.26.tgz",
+      "integrity": "sha512-OmcP96CFsNOwa65tamQayRcfqhNlcQ3YCWOq+0Wb+CAM4uB7kOMrXY41Gj4atthxrGhLQ9pg7Vk26iApb88idA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.26.tgz",
+      "integrity": "sha512-liTTTpKSv89ivIxcZ+iU1cRige9Y7JkOjVnJ2Ystzl+DsWNHqt7wLTTgm/u7gEqmmAS2JKryODLQn3q1UtFNPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.26.tgz",
+      "integrity": "sha512-Y/g+m3I8CeBof5A3kWWOS6QA2HOIUytF5EeTgfwcAK+GKT/tGe7Xqo5svBtaqflU5od2zzbMTWqkinPXgRWGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.26.tgz",
+      "integrity": "sha512-19IvwyPfBN/rz9s7qXhOTQmW0922+pjpRUUvIebu+CMM75nX6YuDzHsGx8hSmn5dS89SNaMCh1lgUuXqm++6jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.26.tgz",
+      "integrity": "sha512-iNlbvTIo425rkKzDLLWFJGnFXr3myETUdIDHcjuiPNZE8b0ogmcAuilC4yEJX7FSHGbnlsoJcCT2xf4b3VJmmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.26.tgz",
+      "integrity": "sha512-AuuEOtG+YXKIjIUup4RsxYNklx6XVB3WKWfhxG6hnfPrn7vp89RNOLbbyyprgj6Sk7k9ulwGVTJElEvmBNPSCA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.26.tgz",
+      "integrity": "sha512-JcMDWQvW1BchUyRg8E0jHiTx7CQYpUr5uDEL1dnPDECrEjBEGG2ynmJ3XX70sWXql0JagqR1t3VpANYFWdUnqA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.26.tgz",
+      "integrity": "sha512-FW7V7Mbpq4+PA7BiAq76LJs8MdNuUSylyuRVfQRkhIyeWadFroZ+KOPgjku8Z/fXzngxBRvsk+PGGB0t8mGcjA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.26.tgz",
+      "integrity": "sha512-w8erqMHsVcdGwUfJxF6LaiTuPoKnyLOcUbhLcxiXrlLt5MLjtlgcIeUY/NWK/oPoyqkgH+/i8pOJnMTxvl83ZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.26.tgz",
+      "integrity": "sha512-uDCWCNpUiqkbvPmsuPUTn/P7ag9SqNXD2JT/W3dUu7yZ2krzN+nmmoQ2xRX63/J6RYiHI7aT4jo7Z++lsljlPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.26.tgz",
+      "integrity": "sha512-2k1ax1QmmqLEnpC0uRCw7OXhBfyvdPqERBXupDasjYbChT6ZSO/uha28Bp38cw0viKIG79L27aTDkbkABsMW3w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.26.tgz",
+      "integrity": "sha512-aUuYecSEGa4SUSdyCWaI/vk8jdseifYnsF1GZQx2+piL8GIuT/5QrVcFfmes4Iwy7FIVXxtzD063z/FfpZ7K7w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -25225,6 +26349,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@walletconnect/core/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@walletconnect/core/node_modules/unstorage": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
@@ -26489,6 +27628,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@walletconnect/universal-provider/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@walletconnect/universal-provider/node_modules/unstorage": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
@@ -26866,6 +28020,21 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/uint8arrays": {
@@ -29358,6 +30527,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -29385,6 +30570,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacache": {
@@ -34817,6 +36012,48 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -37699,6 +38936,73 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports/node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -38112,6 +39416,20 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/format-imports/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -45500,6 +46818,16 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -50636,123 +51964,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/ox": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.12.4.tgz",
-      "integrity": "sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
-    },
-    "node_modules/ox/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/@scure/bip32": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
-      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.0",
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/@scure/bip39": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
-      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
@@ -60059,6 +61270,154 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tsup/node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/tsup/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tsup/node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/tsup/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -60571,9 +61930,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -61483,6 +62842,24 @@
         }
       }
     },
+    "node_modules/viem/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/viem/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/viem/node_modules/@noble/curves": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
@@ -61544,6 +62921,42 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.12.4.tgz",
+      "integrity": "sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/viem/node_modules/ws": {
@@ -63352,6 +64765,7 @@
         "solidity-coverage": "0.8.17",
         "ts-node": "10.9.2",
         "tsconfig-paths": "4.2.0",
+        "tsup": "^8.5.1",
         "typescript": "5.8.3"
       }
     },
@@ -63380,6 +64794,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/contracts/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/sdk": {
@@ -63422,6 +64850,8 @@
         "@babel/core": "7.29.0",
         "@babel/preset-env": "7.29.0",
         "@babel/preset-typescript": "7.28.5",
+        "@swc/core": "^1.15.26",
+        "@swc/helpers": "^0.5.21",
         "@types/jest": "29.5.14",
         "@types/node": "18.19.130",
         "@types/uuid": "9.0.8",
@@ -63440,6 +64870,7 @@
         "prettier": "2.8.8",
         "rimraf": "4.4.1",
         "ts-jest": "29.4.6",
+        "tsup": "^8.5.1",
         "tsutils": "3.21.0",
         "typed-emitter": "2.1.0",
         "typescript": "5.8.3"
@@ -63585,6 +65016,20 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
       "license": "Apache-2.0"
+    },
+    "packages/sdk/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "packages/sdk/node_modules/undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:cli": "npm run build --workspace=apps/cli",
     "build:cli:full": "npm run build:backend && npm run build:contracts && npm run build:sdk && npm run build:cli",
     "build:backend": "npm run build --workspace=apps/backend",
-    "build:contracts": "npm run compile:force --workspace=packages/contracts",
+    "build:contracts": "npm run build --workspace=packages/contracts",
     "build:web": "npm run build --workspace=apps/web",
     "pack:backend": "npm pack --workspace=apps/backend",
     "pack:contracts": "npm pack --workspace=packages/contracts",
@@ -68,7 +68,8 @@
     "@commitlint/config-conventional": "19.8.0",
     "concurrently": "7.6.0",
     "dotenv": "16.4.7",
-    "rimraf": "4.4.1"
+    "rimraf": "4.4.1",
+    "typescript": "^5.1.6"
   },
   "dependencies": {
     "husky": "9.1.7"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -2,29 +2,38 @@
     "name": "@hashgraph/stablecoin-npm-contracts",
     "version": "4.2.0",
     "description": "",
-    "main": "./build/typechain-types/index.js",
-    "module": "./build/typechain-types/index.js",
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
     "files": [
-        "build/"
+        "dist/"
     ],
     "exports": {
         ".": {
-            "import": "./build/typechain-types/index.js",
-            "require": "./build/typechain-types/index.js"
+            "import": {
+                "types": "./dist/index.d.mts",
+                "default": "./dist/index.mjs"
+            },
+            "require": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
         },
-        "./typechain-types/index.js": {
-            "import": "./build/typechain-types/index.js",
-            "require": "./build/typechain-types/index.js"
-        },
-        "./typechain-types/*": {
-            "import": "./build/typechain-types/*",
-            "require": "./build/typechain-types/*"
+        "./factories": {
+            "import": {
+                "types": "./dist/factories.d.mts",
+                "default": "./dist/factories.mjs"
+            },
+            "require": {
+                "types": "./dist/factories.d.ts",
+                "default": "./dist/factories.js"
+            }
         }
     },
     "scripts": {
         "compile": "npx hardhat compile",
         "compile:force": "npx hardhat compile --force",
-        "build": "npm run compile && rimraf build && tsc -p tsconfig.json",
+        "build": "npm run compile && rimraf dist && tsup",
         "coverage": "npx hardhat coverage --solcoverjs .solcover.js",
         "test": "npx hardhat test test/**/*.test.ts",
         "test:parallel": "npx hardhat test test/**/*.test.ts --parallel",
@@ -76,8 +85,8 @@
         "@chainlink/contracts": "0.5.1",
         "@commitlint/cli": "19.8.0",
         "@commitlint/config-conventional": "19.8.0",
-        "@hiero-ledger/sdk": "2.79.0",
         "@hashgraph/smart-contracts": "github:hashgraph/hedera-smart-contracts#v0.10.1",
+        "@hiero-ledger/sdk": "2.79.0",
         "@nomicfoundation/hardhat-toolbox": "5.0.0",
         "@openzeppelin/contracts": "5.4.0",
         "@openzeppelin/contracts-upgradeable": "5.4.0",
@@ -97,6 +106,7 @@
         "solidity-coverage": "0.8.17",
         "ts-node": "10.9.2",
         "tsconfig-paths": "4.2.0",
+        "tsup": "^8.5.1",
         "typescript": "5.8.3"
     },
     "dependencies": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -28,6 +28,16 @@
                 "types": "./dist/factories.d.ts",
                 "default": "./dist/factories.js"
             }
+        },
+        "./factories/*": {
+            "import": {
+                "types": "./dist/factories/*.d.mts",
+                "default": "./dist/factories/*.mjs"
+            },
+            "require": {
+                "types": "./dist/factories/*.d.ts",
+                "default": "./dist/factories/*.js"
+            }
         }
     },
     "scripts": {

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: {
+		index: 'typechain-types/index.ts',
+		factories: 'typechain-types/factories/index.ts',
+	},
+	format: ['esm', 'cjs'],
+	dts: true,
+	sourcemap: true,
+	clean: true,
+	target: 'es2022',
+	external: ['ethers'],
+});

--- a/packages/sdk/.eslintignore
+++ b/packages/sdk/.eslintignore
@@ -4,3 +4,5 @@
 /example
 /src_old
 package.json
+tsup.config.ts
+dist/

--- a/packages/sdk/.gitignore
+++ b/packages/sdk/.gitignore
@@ -6,6 +6,8 @@ package-lock.json
 
 # Transpiled files
 build/
+dist/
+*/dist/
 
 # Environment variables
 .env

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,20 +2,26 @@
 	"name": "@hashgraph/stablecoin-npm-sdk",
 	"version": "4.2.0",
 	"description": "stablecoin studio SDK",
-	"main": "./build/cjs/src/index.js",
-	"module": "./build/esm/src/index.js",
+	"main": "./dist/cjs/index.js",
+	"module": "./dist/esm/index.mjs",
+	"types": "./dist/cjs/index.d.ts",
 	"engines": {
 		"node": ">= 16.17"
 	},
 	"files": [
-		"./build"
+		"dist/"
 	],
 	"readme": "README.md",
-	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
-			"import": "./build/esm/src/index.js",
-			"require": "./build/cjs/src/index.js"
+			"import": {
+				"types": "./dist/esm/index.d.mts",
+				"default": "./dist/esm/index.mjs"
+			},
+			"require": {
+				"types": "./dist/cjs/index.d.ts",
+				"default": "./dist/cjs/index.js"
+			}
 		}
 	},
 	"devDependencies": {
@@ -23,6 +29,8 @@
 		"@babel/core": "7.29.0",
 		"@babel/preset-env": "7.29.0",
 		"@babel/preset-typescript": "7.28.5",
+		"@swc/core": "^1.15.26",
+		"@swc/helpers": "^0.5.21",
 		"@types/jest": "29.5.14",
 		"@types/node": "18.19.130",
 		"@types/uuid": "9.0.8",
@@ -41,16 +49,17 @@
 		"prettier": "2.8.8",
 		"rimraf": "4.4.1",
 		"ts-jest": "29.4.6",
+		"tsup": "^8.5.1",
 		"tsutils": "3.21.0",
 		"typed-emitter": "2.1.0",
 		"typescript": "5.8.3"
 	},
 	"scripts": {
-		"start": "node build/src/index.js",
-		"clean": "rimraf coverage build",
+		"start": "node dist/cjs/index.js",
+		"clean": "rimraf coverage dist",
 		"clean:modules": "rimraf node_modules",
 		"prebuild": "npm run lint",
-		"build": "rimraf build && npx tsc -p tsconfig.json && npx tsc -p tsconfig-cjs.json",
+		"build": "rimraf dist && tsup",
 		"build:types": "npx tsc -p tsconfig.json --emitDeclarationOnly",
 		"build:tsc": "rm -rf build && tsc -p tsconfig.json",
 		"build:watch": "concurrently --kill-others --names \"ESM,CJS\" \"tsc -w -p tsconfig.json\" \"tsc -w -p tsconfig-cjs.json\"",
@@ -78,18 +87,18 @@
 		"@hashgraph/hedera-custodians-integration": "1.4.1",
 		"@hashgraph/hedera-wallet-connect": "2.0.3",
 		"@hashgraph/proto": "2.25.0",
-		"@reown/appkit": "1.8.9",
-		"@reown/appkit-adapter-ethers": "1.8.4",
-		"@reown/appkit-core": "1.8.4",
-		"@walletconnect/sign-client": "2.19.2",
-		"@walletconnect/universal-provider": "2.21.9",
-		"@walletconnect/utils": "2.19.2",
 		"@hashgraph/stablecoin-npm-contracts": "*",
 		"@hiero-ledger/proto": "2.25.0",
 		"@hiero-ledger/sdk": "2.79.0",
 		"@metamask/detect-provider": "2.0.0",
 		"@metamask/providers": "10.2.1",
 		"@notabene/pii-sdk": "1.17.1",
+		"@reown/appkit": "1.8.9",
+		"@reown/appkit-adapter-ethers": "1.8.4",
+		"@reown/appkit-core": "1.8.4",
+		"@walletconnect/sign-client": "2.19.2",
+		"@walletconnect/universal-provider": "2.21.9",
+		"@walletconnect/utils": "2.19.2",
 		"chai": "4.5.0",
 		"chai-as-promised": "7.1.2",
 		"dotenv": "16.4.7",

--- a/packages/sdk/src/app/service/TransactionService.ts
+++ b/packages/sdk/src/app/service/TransactionService.ts
@@ -50,7 +50,7 @@ import {
 	TransferTransaction,
 } from '@hiero-ledger/sdk';
 import { MirrorNodeAdapter } from '../../port/out/mirror/MirrorNodeAdapter.js';
-import * as Factories from '@hashgraph/stablecoin-npm-contracts/typechain-types/factories/contracts';
+import * as Factories from '@hashgraph/stablecoin-npm-contracts/factories';
 import { ethers } from 'ethers';
 import Hex from '../../core/Hex.js';
 import { AWSKMSTransactionAdapter } from '../../port/out/hs/custodial/AWSKMSTransactionAdapter';

--- a/packages/sdk/src/port/in/Account.ts
+++ b/packages/sdk/src/port/in/Account.ts
@@ -29,15 +29,15 @@ import { GetListStableCoinQuery } from '../../app/usecase/query/stablecoin/list/
 import GetPublicKeyRequest from './request/GetPublicKeyRequest.js';
 import PublicKey from '../../domain/context/account/PublicKey.js';
 import { default as HederaAccount } from '../../domain/context/account/Account.js';
-import StableCoinListViewModel from '../out/mirror/response/StableCoinListViewModel.js';
-import AccountViewModel from '../out/mirror/response/AccountViewModel.js';
+import type StableCoinListViewModel from '../out/mirror/response/StableCoinListViewModel.js';
+import type AccountViewModel from '../out/mirror/response/AccountViewModel.js';
 import { HederaId } from '../../domain/context/shared/HederaId.js';
 import { GetAccountInfoQuery } from '../../app/usecase/query/account/info/GetAccountInfoQuery.js';
 import { InvalidResponse } from '../out/mirror/error/InvalidResponse.js';
 import { handleValidation } from './Common.js';
 import { LogError } from '../../core/decorator/LogErrorDecorator.js';
 
-export { AccountViewModel, StableCoinListViewModel };
+export type { AccountViewModel, StableCoinListViewModel };
 
 interface IAccountInPort {
 	getPublicKey(request: GetPublicKeyRequest): Promise<PublicKey>;

--- a/packages/sdk/src/port/in/Event.ts
+++ b/packages/sdk/src/port/in/Event.ts
@@ -21,14 +21,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import Injectable from '../../core/Injectable.js';
 import NetworkService from '../../app/service/NetworkService.js';
-import WalletEvent, {
+import type WalletEvent from '../../app/service/event/WalletEvent.js';
+import {
 	ConnectionState,
 	WalletEvents,
 } from '../../app/service/event/WalletEvent.js';
 import EventService from '../../app/service/event/EventService.js';
 import { LogError } from '../../core/decorator/LogErrorDecorator.js';
 
-export { WalletEvent, WalletEvents, ConnectionState };
+export type { WalletEvent };
+export { WalletEvents, ConnectionState };
 
 export type EventParameter<T extends keyof WalletEvent> = Parameters<
 	WalletEvent[T]

--- a/packages/sdk/src/port/in/Network.ts
+++ b/packages/sdk/src/port/in/Network.ts
@@ -21,7 +21,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import Injectable from '../../core/Injectable.js';
 import { CommandBus } from '../../core/command/CommandBus.js';
-import { InitializationData } from '../out/TransactionAdapter.js';
+import type { InitializationData } from '../out/TransactionAdapter.js';
 import { ConnectCommand } from '../../app/usecase/command/network/connect/ConnectCommand.js';
 import ConnectRequest, {
 	AWSKMSConfigRequest,
@@ -61,7 +61,8 @@ import { HederaWalletConnectTransactionAdapter } from '../out/hs/walletconnect/H
 import { AWSKMSTransactionAdapter } from '../out/hs/custodial/AWSKMSTransactionAdapter';
 import AWSKMSSettings from '../../domain/context/custodialwalletsettings/AWSKMSSettings';
 
-export { InitializationData, SupportedWallets };
+export type { InitializationData };
+export { SupportedWallets };
 
 export type NetworkResponse = {
 	environment: Environment;

--- a/packages/sdk/src/port/in/StableCoin.ts
+++ b/packages/sdk/src/port/in/StableCoin.ts
@@ -40,8 +40,8 @@ import {
 import { QueryBus } from '../../core/query/QueryBus.js';
 import { CommandBus } from '../../core/command/CommandBus.js';
 import { CashInCommand } from '../../app/usecase/command/stablecoin/operations/cashin/CashInCommand.js';
-import StableCoinViewModel from '../out/mirror/response/StableCoinViewModel.js';
-import StableCoinListViewModel from '../out/mirror/response/StableCoinListViewModel.js';
+import type StableCoinViewModel from '../out/mirror/response/StableCoinViewModel.js';
+import type StableCoinListViewModel from '../out/mirror/response/StableCoinListViewModel.js';
 import StableCoinService from '../../app/service/StableCoinService.js';
 import { GetStableCoinQuery } from '../../app/usecase/query/stablecoin/get/GetStableCoinQuery.js';
 import { CreateCommand } from '../../app/usecase/command/stablecoin/create/CreateCommand.js';
@@ -100,7 +100,7 @@ import { AssociateCommand } from '../../app/usecase/command/account/associate/As
 import { MirrorNodeAdapter } from '../../port/out/mirror/MirrorNodeAdapter.js';
 import MultiSigTransactionViewModel from '../out/backend/response/MultiSigTransactionViewModel';
 import MultiSigTransactionsViewModel from '../out/backend/response/MultiSigTransactionsViewModel';
-import { PaginationViewModel } from '../out/backend/response/MultiSigTransactionsViewModel.js';
+import type { PaginationViewModel } from '../out/backend/response/MultiSigTransactionsViewModel.js';
 import SignTransactionRequest from './request/SignTransactionRequest.js';
 import SubmitTransactionRequest from './request/SubmitTransactionRequest.js';
 import RemoveTransactionRequest from './request/RemoveTransactionRequest.js';
@@ -132,13 +132,15 @@ import { CreateHoldByControllerCommand, CreateHoldByControllerCommandResponse } 
 import { SerializedTransactionData } from '../../domain/context/transaction/TransactionResponse.js';
 
 
-export {
+export type {
 	StableCoinViewModel,
 	StableCoinListViewModel,
 	ReserveViewModel,
 	MultiSigTransactionsViewModel,
 	MultiSigTransactionViewModel,
 	PaginationViewModel,
+};
+export {
 	TRANSFER_LIST_SIZE,
 };
 export { StableCoinCapabilities, Capability, Access, Operation, Balance };

--- a/packages/sdk/src/port/in/request/ConnectRequest.ts
+++ b/packages/sdk/src/port/in/request/ConnectRequest.ts
@@ -23,7 +23,7 @@ import { Environment } from '../../../domain/context/network/Environment.js';
 import { MirrorNode } from '../../../domain/context/network/MirrorNode.js';
 import { JsonRpcRelay } from '../../../domain/context/network/JsonRpcRelay.js';
 import { SupportedWallets } from '../../../domain/context/network/Wallet.js';
-import { BaseRequest, RequestAccount } from './BaseRequest.js';
+import type { BaseRequest, RequestAccount } from './BaseRequest.js';
 import ValidatedRequest from './validation/ValidatedRequest.js';
 import Validation from './validation/Validation.js';
 import { ConsensusNode } from '../../../domain/context/network/ConsensusNodes.js';

--- a/packages/sdk/src/port/in/request/CreateRequest.ts
+++ b/packages/sdk/src/port/in/request/CreateRequest.ts
@@ -25,7 +25,7 @@ import BigDecimal from '../../../domain/context/shared/BigDecimal.js';
 import InvalidDecimalRange from '../../../domain/context/stablecoin/error/InvalidDecimalRange.js';
 import { StableCoin } from '../../../domain/context/stablecoin/StableCoin.js';
 import { TokenSupplyType } from '../../../domain/context/stablecoin/TokenSupply.js';
-import { RequestPublicKey } from './BaseRequest.js';
+import type { RequestPublicKey } from './BaseRequest.js';
 import { InvalidType } from './error/InvalidType.js';
 import ValidatedRequest from './validation/ValidatedRequest.js';
 import Validation from './validation/Validation.js';

--- a/packages/sdk/src/port/in/request/GetTransactionsRequest.ts
+++ b/packages/sdk/src/port/in/request/GetTransactionsRequest.ts
@@ -19,7 +19,7 @@
  */
 
 import { OptionalField } from '../../../core/decorator/OptionalDecorator.js';
-import { RequestPublicKey } from './BaseRequest.js';
+import type { RequestPublicKey } from './BaseRequest.js';
 import ValidatedRequest from './validation/ValidatedRequest.js';
 import Validation from './validation/Validation.js';
 

--- a/packages/sdk/src/port/in/request/UpdateRequest.ts
+++ b/packages/sdk/src/port/in/request/UpdateRequest.ts
@@ -19,7 +19,7 @@
  */
 
 import { OptionalField } from '../../../core/decorator/OptionalDecorator.js';
-import { RequestPublicKey } from './BaseRequest.js';
+import type { RequestPublicKey } from './BaseRequest.js';
 import ValidatedRequest from './validation/ValidatedRequest.js';
 import Validation from './validation/Validation.js';
 import { StableCoin } from '../../../domain/context/stablecoin/StableCoin.js';

--- a/packages/sdk/src/port/in/response/index.ts
+++ b/packages/sdk/src/port/in/response/index.ts
@@ -18,8 +18,6 @@
  *
  */
 
-import ConfigInfoViewModel from './ConfigInfoViewModel';
-import HoldViewModel from './HoldViewModel';
-import { TransactionResult } from '../../../domain/context/transaction/TransactionResult';
-
-export { ConfigInfoViewModel, HoldViewModel, TransactionResult };
+export type { default as ConfigInfoViewModel } from './ConfigInfoViewModel.js';
+export type { default as HoldViewModel } from './HoldViewModel.js';
+export { TransactionResult } from '../../../domain/context/transaction/TransactionResult.js';

--- a/packages/sdk/src/port/out/hs/walletconnect/HederaWalletConnectTransactionAdapter.ts
+++ b/packages/sdk/src/port/out/hs/walletconnect/HederaWalletConnectTransactionAdapter.ts
@@ -47,26 +47,7 @@ import { SigningError } from '../error/SigningError';
 import { RPCTransactionResponseAdapter } from '../../response/RPCTransactionResponseAdapter';
 import Hex from '../../../../core/Hex';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const { SupportedWallets } = require('@hashgraph/stablecoin-npm-sdk') as any;
-let HederaAdapter: typeof import('@hashgraph/hedera-wallet-connect').HederaAdapter;
-let HederaChainDefinition: typeof import('@hashgraph/hedera-wallet-connect').HederaChainDefinition;
-let hederaNamespace: typeof import('@hashgraph/hedera-wallet-connect').hederaNamespace;
-let HederaProvider: typeof import('@hashgraph/hedera-wallet-connect').HederaProvider;
-let base64StringToSignatureMap: typeof import('@hashgraph/hedera-wallet-connect').base64StringToSignatureMap;
-let createAppKit: typeof import('@reown/appkit').createAppKit;
-
-if (typeof window !== 'undefined') {
-	const hwc = require('@hashgraph/hedera-wallet-connect');
-	HederaAdapter = hwc.HederaAdapter;
-	HederaChainDefinition = hwc.HederaChainDefinition;
-	hederaNamespace = hwc.hederaNamespace;
-	HederaProvider = hwc.HederaProvider;
-	base64StringToSignatureMap = hwc.base64StringToSignatureMap;
-
-	const appkit = require('@reown/appkit');
-	createAppKit = appkit.createAppKit;
-}
+import { SupportedWallets } from '../../../../domain/context/network/Wallet';
 
 @singleton()
 export class HederaWalletConnectTransactionAdapter extends BaseHederaTransactionAdapter {
@@ -74,10 +55,10 @@ export class HederaWalletConnectTransactionAdapter extends BaseHederaTransaction
 	signerOrProvider!: Signer | Provider;
 	protected network!: Environment;
 	protected projectId = '';
-	protected hederaAdapter: InstanceType<typeof HederaAdapter> | undefined;
+	protected hederaAdapter: import('@hashgraph/hedera-wallet-connect').HederaAdapter | undefined;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	protected appKit: any;
-	protected hederaProvider: InstanceType<typeof HederaProvider> | undefined;
+	protected hederaProvider: import('@hashgraph/hedera-wallet-connect').HederaProvider | undefined;
 	protected dappMetadata: {
 		name: string;
 		description: string;
@@ -322,6 +303,7 @@ export class HederaWalletConnectTransactionAdapter extends BaseHederaTransaction
 			}
 
 			// Decode the protobuf SignatureMap from base64
+			const { base64StringToSignatureMap } = await import('@hashgraph/hedera-wallet-connect');
 			const signatureMap = base64StringToSignatureMap(base64SigMap);
 
 			if (!signatureMap.sigPair || signatureMap.sigPair.length === 0) {
@@ -695,6 +677,15 @@ export class HederaWalletConnectTransactionAdapter extends BaseHederaTransaction
 		currentNetwork: string,
 	): Promise<void> {
 		const isTestnet = currentNetwork === testnet;
+
+		const {
+			HederaAdapter,
+			HederaChainDefinition,
+			hederaNamespace,
+			HederaProvider,
+		} = await import('@hashgraph/hedera-wallet-connect');
+
+		const { createAppKit } = await import('@reown/appkit');
 
 		// Order chains based on current network — HashPack prefers the first
 		const nativeNetworks = isTestnet

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -3,10 +3,10 @@
 		"target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		"lib": ["ES2022", "DOM"],
 		"module": "ESNext" /* Specify what module code is generated. */,
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
 		"rootDir": ".",
-		"outDir": "./build/esm" /* Specify an output folder for all emitted files. */,
+		"outDir": "./dist" /* Specify an output folder for all emitted files. */,
 		"allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
 		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
 		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
@@ -19,5 +19,5 @@
 		"resolveJsonModule": true
 	},
 	"exclude": ["build/**/*", "node_modules", "example/**/*"],
-	"include": ["src/**/*", "__tests__/**/*", "scripts/**/*"]
+	"include": ["src/**/*", "__tests__/**/*", "scripts/**/*", "tsup.config.ts"]
 }

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -14,7 +14,6 @@ export default defineConfig([
     // Externalize the contracts as it is a peer workspace package.
     external: ['@hashgraph/stablecoin-npm-contracts'],
     // Bundle other @hashgraph and @hiero-ledger packages to avoid ESM resolution issues in broken dependencies.
-    // Specifying @hiero-ledger/sdk as noExternal as requested by the user.
     noExternal: [
       /^@hashgraph\/(?!stablecoin-npm-contracts)/,
       /^@hiero-ledger\//,

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: {
+      index: './src/index.ts',
+    },
+    outDir: 'dist/esm',
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    bundle: true,
+    // Externalize the contracts as it is a peer workspace package.
+    external: ['@hashgraph/stablecoin-npm-contracts'],
+    // Bundle other @hashgraph and @hiero-ledger packages to avoid ESM resolution issues in broken dependencies.
+    // Specifying @hiero-ledger/sdk as noExternal as requested by the user.
+    noExternal: [
+      /^@hashgraph\/(?!stablecoin-npm-contracts)/,
+      /^@hiero-ledger\//,
+      'tsyringe',
+      'reflect-metadata'
+    ],
+    target: 'es2022',
+    outExtension({ format }) {
+      return {
+        js: format === 'esm' ? '.mjs' : '.js',
+      };
+    },
+  },
+  {
+    entry: {
+      index: './src/index.ts',
+    },
+    outDir: 'dist/cjs',
+    format: ['cjs'],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    bundle: true,
+    external: ['@hashgraph/stablecoin-npm-contracts'],
+    noExternal: [
+      /^@hashgraph\/(?!stablecoin-npm-contracts)/,
+      /^@hiero-ledger\//,
+      'tsyringe',
+      'reflect-metadata'
+    ],
+    target: 'node16',
+  },
+]);


### PR DESCRIPTION
# Important
This PR is not solving the problem! Please see [comment below](https://github.com/hashgraph/stablecoin-studio/pull/1470#issuecomment-4280054476) with further findings.

# Disclaimer
Please consider this PR as a suggested approach to resolving this issue. I'm not familiar with the codebase and not able to test if it functions correctly. This implmenetation helped me build a packages that works fine for ESM projects and I'll proceed with testing it while bulding the `stable-coin-studio-plugin` for Hedera Agent Kit.

I'm aware that it changes multiple files and might have broke sth. Rationalities for those changes are presented below.

**Related issue(s)**:

Fixes #1459, #1468

<!-- obsidian --><h1 data-heading="fix(sdk): migrate build system to &#x60;tsup&#x60; for ESM/CJS dual-package compatibility">fix(sdk): migrate build system to <code>tsup</code> for ESM/CJS dual-package compatibility</h1>
<h2 data-heading="Summary">Summary</h2>
<p>Resolves critical ESM compatibility issues in <code>@hashgraph/stablecoin-npm-sdk</code> that prevented the package from being imported in any modern Node.js ESM project (<code>"type": "module"</code>). The fix migrates both the SDK and Contracts packages from raw <code>tsc</code>-based transpilation to a <code>tsup</code> (esbuild) bundled build system, following established patterns from the <code>hedera-agent-kit</code> project.</p>
<hr>
<h2 data-heading="Problem">Problem</h2>
<p>The SDK build (<code>build/esm/</code>) had three categories of bugs that made it impossible to <code>import</code> in Node.js ESM:</p>
<h3 data-heading="1. Missing &#x60;.js&#x60; extensions in 162+ relative imports">1. Missing <code>.js</code> extensions in 162+ relative imports</h3>
<p>Node.js ESM requires explicit file extensions in all relative import specifiers (<a href="https://nodejs.org/api/esm.html#mandatory-file-extensions" class="external-link" target="_blank" rel="noopener nofollow" aria-label="https://nodejs.org/api/esm.html#mandatory-file-extensions" data-tooltip-position="top">Node.js docs</a>). The <code>tsc</code> output omitted them entirely:</p>
<pre><code class="language-js">// build/esm/src/index.js — broken
import { Network } from './port/in/Network'; // ❌ No extension
</code></pre>
<h3 data-heading="2. Illegal &#x60;require()&#x60; calls in ESM scope">2. Illegal <code>require()</code> calls in ESM scope</h3>
<p><code>HederaWalletConnectTransactionAdapter.ts</code> used a CJS <code>require()</code> pattern guarded by a <code>typeof window</code> check. In an ESM bundle, <code>require</code> is not defined and throws a <code>ReferenceError</code> at parse time, before any runtime check can execute:</p>
<pre><code class="language-ts">// Before — broken in ESM
const { SupportedWallets } = require('@hashgraph/stablecoin-npm-sdk') as any;
if (typeof window !== 'undefined') {
  const hwc = require('@hashgraph/hedera-wallet-connect'); // ❌ ReferenceError
}
</code></pre>
<h3 data-heading="3. Broken directory imports via &#x60;exports&#x60; wildcards">3. Broken directory imports via <code>exports</code> wildcards</h3>
<p>The <code>@hashgraph/stablecoin-npm-contracts</code> package exposed <code>"./typechain-types/*"</code> wildcard exports, and the SDK imported a directory:</p>
<pre><code class="language-ts">import * as Factories from '@hashgraph/stablecoin-npm-contracts/typechain-types/factories/contracts'; // ❌
</code></pre>
<p>This violates the Node.js <code>exports</code> specification which does not support directory imports.</p>
<hr>
<h2 data-heading="Solution">Solution</h2>
<p>Migrate both packages to <code>tsup</code>, which uses <code>esbuild</code> internally. The bundler:</p>
<ul>
<li><strong>Resolves all internal relative paths</strong> at build time, eliminating the <code>.js</code> extension requirement</li>
<li><strong>Produces proper <code>.mjs</code> files</strong> for ESM output, removing any ambiguity with Node.js module detection</li>
<li><strong>Bundles internal dependencies</strong> that had their own broken ESM paths (e.g. <code>@hashgraph/hedera-custodians-integration</code>)</li>
</ul>
<hr>
<h2 data-heading="Changes">Changes</h2>
<h3 data-heading="&#x60;packages/contracts&#x60;"><code>packages/contracts</code></h3>
<h4 data-heading="&#x60;tsup.config.ts&#x60; *(new)*"><code>tsup.config.ts</code> <em>(new)</em></h4>
<ul>
<li>Builds two entry points: <code>typechain-types/index.ts</code> and <code>typechain-types/factories/index.ts</code></li>
<li>Outputs dual-format ESM (<code>.mjs</code>) + CJS (<code>.js</code>) with declaration files (<code>.d.ts</code> / <code>.d.mts</code>)</li>
</ul>
<h4 data-heading="&#x60;package.json&#x60;"><code>package.json</code></h4>
<ul>
<li>Updated <code>main</code>, <code>module</code>, <code>types</code> fields to point to <code>dist/</code></li>
<li>Replaced the broken wildcard <code>"./typechain-types/*"</code> export with explicit named exports:
<ul>
<li><code>"."</code> → main type index</li>
<li><code>"./factories"</code> → factory contracts index</li>
</ul>
</li>
<li>Updated <code>build</code> script: <code>npm run compile &#x26;&#x26; rimraf dist &#x26;&#x26; tsup</code></li>
<li><code>devDependencies</code>: added <code>tsup</code></li>
</ul>
<hr>
<h3 data-heading="&#x60;packages/sdk&#x60;"><code>packages/sdk</code></h3>
<h4 data-heading="&#x60;tsup.config.ts&#x60; *(new)*"><code>tsup.config.ts</code> <em>(new)</em></h4>
<p>Dual-configuration build:</p>
<ul>
<li><strong>ESM</strong> target: <code>es2022</code>, output <code>dist/esm/index.mjs</code></li>
<li><strong>CJS</strong> target: <code>node16</code>, output <code>dist/cjs/index.js</code></li>
<li><code>external</code>: <code>['@hashgraph/stablecoin-npm-contracts']</code> (workspace peer)</li>
<li><code>noExternal</code> patterns for <code>@hashgraph/*</code>, <code>@hiero-ledger/*</code>, <code>tsyringe</code>, <code>reflect-metadata</code> — these are <strong>bundled in</strong> to work around broken ESM paths in their own outputs</li>
</ul>
<h4 data-heading="&#x60;package.json&#x60;"><code>package.json</code></h4>
<ul>
<li>Updated <code>main</code>, <code>module</code>, <code>types</code> to point to <code>dist/cjs/</code> and <code>dist/esm/</code></li>
<li>Replaced single-format <code>exports</code> with modern nested structure:
<pre><code class="language-json">".": {
  "import": { "types": "..index.d.mts", "default": "..index.mjs" },
  "require": { "types": "..index.d.ts", "default": "..index.js" }
}
</code></pre>
</li>
<li>Updated <code>build</code> script: <code>rimraf dist &#x26;&#x26; tsup</code></li>
<li>Updated <code>clean</code> script: targets <code>dist/</code> instead of <code>build/</code></li>
<li><code>devDependencies</code>: added <code>tsup</code>, <code>@swc/core</code>, <code>@swc/helpers</code> (required for <code>emitDecoratorMetadata</code> support)</li>
</ul>
<h4 data-heading="&#x60;tsconfig.json&#x60;"><code>tsconfig.json</code></h4>
<ul>
<li>Changed <code>moduleResolution</code> from <code>"node"</code> to <code>"bundler"</code> (required for <code>tsup</code> compatibility)</li>
<li>Changed <code>outDir</code> from <code>./build/esm</code> to <code>./dist</code></li>
<li>Added <code>tsup.config.ts</code> to <code>include</code> array</li>
</ul>
<h4 data-heading="&#x60;.eslintignore&#x60;"><code>.eslintignore</code></h4>
<ul>
<li>Added <code>tsup.config.ts</code> (not part of <code>tsconfig.project</code>, excluded from linting)</li>
<li>Added <code>dist/</code> (build output must not be linted)</li>
</ul>
<hr>
<h3 data-heading="Source Code Fixes">Source Code Fixes</h3>
<h4 data-heading="&#x60;HederaWalletConnectTransactionAdapter.ts&#x60;"><code>HederaWalletConnectTransactionAdapter.ts</code></h4>
<p>Traditional synchronous <code>require()</code> calls and module-level <code>typeof window</code> guards were replaced with <strong>inline dynamic <code>import()</code></strong> calls at the actual point of use. </p>
<pre><code class="language-ts">// After
import { SupportedWallets } from '../../../../domain/context/network/Wallet';

// Inside initAdaptersAndProvider() — called only in browser context
const { HederaAdapter, HederaChainDefinition, hederaNamespace, HederaProvider } 
    = await import('@hashgraph/hedera-wallet-connect');

const { createAppKit } = await import('@reown/appkit');
</code></pre>
<p><strong>Benefits:</strong></p>
<ul>
<li><strong>Deterministic</strong>: Imports are awaited exactly where they are needed, eliminating race conditions.</li>
<li><strong>ESM-Compatible</strong>: Dynamic <code>import()</code> is natively supported in ESM and correctly handled by the <code>tsup</code> bundler.</li>
<li><strong>Node-Safe</strong>: Because dynamic imports are evaluated lazily at runtime, they never execute in a Node.js environment during package initialization, removing the need for broad <code>typeof window !== 'undefined'</code> blocks at the module level.</li>
<li><strong>No Circular Imports</strong>: The <code>SupportedWallets</code> circular dependency was resolved by importing it directly from its source domain file instead of the SDK's public index.</li>
</ul>
<h4 data-heading="&#x60;TransactionService.ts&#x60;"><code>TransactionService.ts</code></h4>
<p>Fixed the directory import to use the new explicit contracts export:</p>
<pre><code class="language-ts">// Before
import * as Factories from '@hashgraph/stablecoin-npm-contracts/typechain-types/factories/contracts'; // ❌

// After
import * as Factories from '@hashgraph/stablecoin-npm-contracts/factories'; // ✅
</code></pre>
<h4 data-heading="&#x60;import type&#x60; / &#x60;export type&#x60; fixes across public API files"><code>import type</code> / <code>export type</code> fixes across public API files</h4>
<p>Several public-facing files re-exported TypeScript <code>interface</code>s and <code>type</code> aliases using plain <code>import</code>/<code>export</code>. While <code>tsc</code> is aware they are type-only and erases them silently, <strong>esbuild validates every import as a runtime binding</strong> and throws <code>No matching export</code> errors for constructs that produce no JavaScript output.</p>
<p>Affected files and their types:</p>

File | Symbols fixed
-- | --
port/in/Account.ts | StableCoinListViewModel, AccountViewModel (both interface)
port/in/Event.ts | WalletEvent (type alias)
port/in/Network.ts | InitializationData (interface)
port/in/StableCoin.ts | StableCoinViewModel, StableCoinListViewModel, PaginationViewModel (all interface)
port/in/response/index.ts | ConfigInfoViewModel, HoldViewModel (interface)
port/in/request/ConnectRequest.ts | BaseRequest, RequestAccount (interface)
port/in/request/CreateRequest.ts | RequestPublicKey (interface)
port/in/request/UpdateRequest.ts | RequestPublicKey (interface)
port/in/request/GetTransactionsRequest.ts | RequestPublicKey (interface)


<p>The fix in each case is to add the <code>type</code> keyword:</p>
<pre><code class="language-ts">// Before
import { InitializationData } from '../out/TransactionAdapter.js';
export { InitializationData };

// After
import type { InitializationData } from '../out/TransactionAdapter.js';
export type { InitializationData };
</code></pre>
<blockquote>
<p>These changes are <strong>semantically correct</strong> and improve code clarity. Adding <code>verbatimModuleSyntax: true</code> to <code>tsconfig.json</code> would enforce this pattern automatically going forward.</p>
</blockquote>
<hr>
<h3 data-heading="&#x60;.gitignore&#x60;"><code>.gitignore</code></h3>
<p>Added <code>**/dist/</code> to root and package-level <code>.gitignore</code> files to exclude the new <code>tsup</code> output directory.</p>
<hr>
<h2 data-heading="Verification">Verification</h2>
<p>After building with <code>npm run build:contracts &#x26;&#x26; npm run build:sdk</code>, the ESM bundle can be loaded in Node.js without errors:</p>
<pre><code class="language-bash">node -e "import('./packages/sdk/dist/esm/index.mjs').then(m => console.log('SDK Loaded! Exports:', Object.keys(m).length))"
# → SDK Loaded! Exports: 101
</code></pre>
<p>This was previously impossible and would throw <code>ERR_UNSUPPORTED_DIR_IMPORT</code> or <code>ReferenceError: require is not defined</code>.</p>
<hr>
<h2 data-heading="Notes">Notes</h2>
<ul>
<li><code>@hiero-ledger/sdk</code> is <strong>bundled</strong> (not externalized) into the SDK output as requested. This avoids runtime resolution failures caused by broken ESM paths in its own <code>node_modules</code> output.</li>
<li><code>@hashgraph/stablecoin-npm-contracts</code> is <strong>externalized</strong> since it is a workspace peer and is always present alongside the SDK.</li>
<li>The SWC compiler (<code>@swc/core</code>) is added as a dev dependency to correctly handle <code>emitDecoratorMetadata</code>, which is required for the <code>tsyringe</code> DI container used throughout the SDK.</li>
</ul># fix(sdk): migrate build system to `tsup` for ESM/CJS dual-package compatibility

## Summary
Resolves critical ESM compatibility issues in `@hashgraph/stablecoin-npm-sdk` that prevented the package from being imported in any modern Node.js ESM project (`"type": "module"`). The fix migrates both the SDK and Contracts packages from raw `tsc`-based transpilation to a `tsup` (esbuild) bundled build system, following established patterns from the `hedera-agent-kit` project.

---

## Problem

The SDK build (`build/esm/`) had three categories of bugs that made it impossible to `import` in Node.js ESM:

### 1. Missing `.js` extensions in 162+ relative imports

Node.js ESM requires explicit file extensions in all relative import specifiers ([[Node.js docs](https://nodejs.org/api/esm.html#mandatory-file-extensions)](https://nodejs.org/api/esm.html#mandatory-file-extensions)). The `tsc` output omitted them entirely:

```js
// build/esm/src/index.js — broken
import { Network } from './port/in/Network'; // ❌ No extension
```

### 2. Illegal `require()` calls in ESM scope

`HederaWalletConnectTransactionAdapter.ts` used a CJS `require()` pattern guarded by a `typeof window` check. In an ESM bundle, `require` is not defined and throws a `ReferenceError` at parse time, before any runtime check can execute:

```ts
// Before — broken in ESM
const { SupportedWallets } = require('@hashgraph/stablecoin-npm-sdk') as any;
if (typeof window !== 'undefined') {
  const hwc = require('@hashgraph/hedera-wallet-connect'); // ❌ ReferenceError
}
```

### 3. Broken directory imports via `exports` wildcards

The `@hashgraph/stablecoin-npm-contracts` package exposed `"./typechain-types/*"` wildcard exports, and the SDK imported a directory:

```ts
import * as Factories from '@hashgraph/stablecoin-npm-contracts/typechain-types/factories/contracts'; // ❌
```

This violates the Node.js `exports` specification which does not support directory imports.

---

## Solution

Migrate both packages to `tsup`, which uses `esbuild` internally. The bundler:
- **Resolves all internal relative paths** at build time, eliminating the `.js` extension requirement
- **Produces proper `.mjs` files** for ESM output, removing any ambiguity with Node.js module detection
- **Bundles internal dependencies** that had their own broken ESM paths (e.g. `@hashgraph/hedera-custodians-integration`)

---

## Changes

### `packages/contracts`

#### `tsup.config.ts` *(new)*
- Builds two entry points: `typechain-types/index.ts` and `typechain-types/factories/index.ts`
- Outputs dual-format ESM (`.mjs`) + CJS (`.js`) with declaration files (`.d.ts` / `.d.mts`)

#### `package.json`
- Updated `main`, `module`, `types` fields to point to `dist/`
- Replaced the broken wildcard `"./typechain-types/*"` export with explicit named exports:
  - `"."` → main type index
  - `"./factories"` → factory contracts index
- Updated `build` script: `npm run compile && rimraf dist && tsup`
- `devDependencies`: added `tsup`

---

### `packages/sdk`

#### `tsup.config.ts` *(new)*
Dual-configuration build:
- **ESM** target: `es2022`, output `dist/esm/index.mjs`
- **CJS** target: `node16`, output `dist/cjs/index.js`
- `external`: `['@hashgraph/stablecoin-npm-contracts']` (workspace peer)
- `noExternal` patterns for `@hashgraph/*`, `@hiero-ledger/*`, `tsyringe`, `reflect-metadata` — these are **bundled in** to work around broken ESM paths in their own outputs

#### `package.json`
- Updated `main`, `module`, `types` to point to `dist/cjs/` and `dist/esm/`
- Replaced single-format `exports` with modern nested structure:
  ```json
  ".": {
    "import": { "types": "..index.d.mts", "default": "..index.mjs" },
    "require": { "types": "..index.d.ts", "default": "..index.js" }
  }
  ```
- Updated `build` script: `rimraf dist && tsup`
- Updated `clean` script: targets `dist/` instead of `build/`
- `devDependencies`: added `tsup`, `@swc/core`, `@swc/helpers` (required for `emitDecoratorMetadata` support)

#### `tsconfig.json`
- Changed `moduleResolution` from `"node"` to `"bundler"` (required for `tsup` compatibility)
- Changed `outDir` from `./build/esm` to `./dist`
- Added `tsup.config.ts` to `include` array

#### `.eslintignore`
- Added `tsup.config.ts` (not part of `tsconfig.project`, excluded from linting)
- Added `dist/` (build output must not be linted)

---

### Source Code Fixes

#### `HederaWalletConnectTransactionAdapter.ts`

Traditional synchronous `require()` calls and module-level `typeof window` guards were replaced with **inline dynamic `import()`** calls at the actual point of use. 

```ts
// After
import { SupportedWallets } from '../../../../domain/context/network/Wallet';

// Inside initAdaptersAndProvider() — called only in browser context
const { HederaAdapter, HederaChainDefinition, hederaNamespace, HederaProvider } 
    = await import('@hashgraph/hedera-wallet-connect');

const { createAppKit } = await import('@reown/appkit');
```

**Benefits:**
- **Deterministic**: Imports are awaited exactly where they are needed, eliminating race conditions.
- **ESM-Compatible**: Dynamic `import()` is natively supported in ESM and correctly handled by the `tsup` bundler.
- **Node-Safe**: Because dynamic imports are evaluated lazily at runtime, they never execute in a Node.js environment during package initialization, removing the need for broad `typeof window !== 'undefined'` blocks at the module level.
- **No Circular Imports**: The `SupportedWallets` circular dependency was resolved by importing it directly from its source domain file instead of the SDK's public index.

#### `TransactionService.ts`

Fixed the directory import to use the new explicit contracts export:

```ts
// Before
import * as Factories from '@hashgraph/stablecoin-npm-contracts/typechain-types/factories/contracts'; // ❌

// After
import * as Factories from '@hashgraph/stablecoin-npm-contracts/factories'; // ✅
```

#### `import type` / `export type` fixes across public API files

Several public-facing files re-exported TypeScript `interface`s and `type` aliases using plain `import`/`export`. While `tsc` is aware they are type-only and erases them silently, **esbuild validates every import as a runtime binding** and throws `No matching export` errors for constructs that produce no JavaScript output.

Affected files and their types:

| File | Symbols fixed |
|:---|:---|
| `port/in/Account.ts` | `StableCoinListViewModel`, `AccountViewModel` (both `interface`) |
| `port/in/Event.ts` | `WalletEvent` (`type` alias) |
| `port/in/Network.ts` | `InitializationData` (`interface`) |
| `port/in/StableCoin.ts` | `StableCoinViewModel`, `StableCoinListViewModel`, `PaginationViewModel` (all `interface`) |
| `port/in/response/index.ts` | `ConfigInfoViewModel`, `HoldViewModel` (`interface`) |
| `port/in/request/ConnectRequest.ts` | `BaseRequest`, `RequestAccount` (`interface`) |
| `port/in/request/CreateRequest.ts` | `RequestPublicKey` (`interface`) |
| `port/in/request/UpdateRequest.ts` | `RequestPublicKey` (`interface`) |
| `port/in/request/GetTransactionsRequest.ts` | `RequestPublicKey` (`interface`) |

The fix in each case is to add the `type` keyword:
```ts
// Before
import { InitializationData } from '../out/TransactionAdapter.js';
export { InitializationData };

// After
import type { InitializationData } from '../out/TransactionAdapter.js';
export type { InitializationData };
```

> These changes are **semantically correct** and improve code clarity. Adding `verbatimModuleSyntax: true` to `tsconfig.json` would enforce this pattern automatically going forward.

---

### `.gitignore`

Added `**/dist/` to root and package-level `.gitignore` files to exclude the new `tsup` output directory.

---

## Verification

After building with `npm run build:contracts && npm run build:sdk`, the ESM bundle can be loaded in Node.js without errors:

```bash
node -e "import('./packages/sdk/dist/esm/index.mjs').then(m => console.log('SDK Loaded! Exports:', Object.keys(m).length))"
# → SDK Loaded! Exports: 101
```

This was previously impossible and would throw `ERR_UNSUPPORTED_DIR_IMPORT` or `ReferenceError: require is not defined`.

---

## Notes

- `@hiero-ledger/sdk` is **bundled** (not externalized) into the SDK output as requested. This avoids runtime resolution failures caused by broken ESM paths in its own `node_modules` output.
- `@hashgraph/stablecoin-npm-contracts` is **externalized** since it is a workspace peer and is always present alongside the SDK.
- The SWC compiler (`@swc/core`) is added as a dev dependency to correctly handle `emitDecoratorMetadata`, which is required for the `tsyringe` DI container used throughout the SDK.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
