### PR TITLE
fix(backend): Dockerfile build stage installs devDependencies for `nest build`

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -37,17 +37,26 @@ FROM node:20.11.1-alpine3.19 as build
 WORKDIR /app
 # RUN apk add --no-cache libc6-compat
 
-# Set to production environment
-ENV NODE_ENV production
+# Build stage runs as development so `npm ci` installs devDependencies
+# (NestJS CLI lives in apps/backend's devDependencies; without it
+# `nest build` fails with `sh: nest: not found`). The final production
+# stage below copies dist + production-only node_modules — devDeps
+# don't ship in the runtime image.
+ENV NODE_ENV development
 
 # Re-create non-root user for Docker
 # RUN addgroup --system --gid 1001 node
 # RUN adduser --system --uid 1001 node
 
-# Copy workspace root files
+# Copy workspace root manifests + the backend workspace's package.json so
+# `npm ci` resolves the backend workspace and installs its devDependencies.
+# Without apps/backend/package.json on disk before `npm ci`, npm skips
+# the workspace's deps entirely and `nest build` fails even though
+# devDeps are nominally enabled.
 COPY --chown=node:node package*.json ./
+COPY --chown=node:node apps/backend/package.json ./apps/backend/
 
-# Install all workspace dependencies
+# Install all workspace dependencies (incl. devDeps — needed for `nest build`)
 RUN npm ci
 
 # Copy backend source code


### PR DESCRIPTION
The `apps/backend` Docker image fails to build from a clean checkout. Reproducible by running `docker build -f apps/backend/Dockerfile --target=production .` from the repo root.

## Symptom

```
#12 [build 7/9] RUN npm run build
#12 0.490 sh: nest: not found
#12 0.491 npm ERR! Lifecycle script `build` failed with error:
#12 0.492 npm ERR! Error: command failed
#12 ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1
```

## Root cause

Two issues in the `build` stage of `apps/backend/Dockerfile`, each independently sufficient to cause the failure:

**1. `ENV NODE_ENV production` immediately after `FROM`**

Historically (npm <8) made `npm ci` skip `devDependencies`. Modern npm ignores `NODE_ENV` for install/ci defaults, but the line is misleading and would re-bite if any future tooling in the build path honours it.

**2. `apps/backend/package.json` not on disk before `npm ci`** _(the actual root cause today)_

`npm ci` runs at `/app` with only the workspace root `package*.json` copied. `apps/backend/package.json` isn't copied until two steps later, so npm doesn't resolve the workspace and skips its deps entirely — including the NestJS CLI in `devDependencies`. `nest build` then can't find `nest` despite "all workspace dependencies" being installed.

## Fix

```diff
 FROM node:20.11.1-alpine3.19 as build
 WORKDIR /app
-# Set to production environment
-ENV NODE_ENV production
+# Build stage uses NODE_ENV=development so `npm ci` installs devDependencies.
+ENV NODE_ENV development

-# Copy workspace root files
 COPY --chown=node:node package*.json ./
+COPY --chown=node:node apps/backend/package.json ./apps/backend/

-# Install all workspace dependencies
+# Install all workspace dependencies (incl. devDeps — needed for `nest build`)
 RUN npm ci
```

The final `production` runtime stage (further down in the same Dockerfile) keeps `NODE_ENV=production` and copies only `dist` + production `node_modules`, so the shipping image is unchanged.

## Verification

`docker build -f apps/backend/Dockerfile --target=production .` completes successfully.

## Note

`apps/web/Dockerfile` has the same workspace-manifest pattern done correctly (it copies `packages/sdk/package.json` and `apps/web/package.json` before `npm ci`). This PR brings the backend Dockerfile in line with that pattern.