### PR TITLE
fix: check held balance in rescue operation

### DIFF
--- a/packages/contracts/contracts/extensions/Interfaces/IRescuable.sol
+++ b/packages/contracts/contracts/extensions/Interfaces/IRescuable.sol
@@ -34,6 +34,15 @@ interface IRescuable {
     error HBARRescueError(uint256 amount);
 
     /**
+     * @dev Emitted when the requested rescue amount exceeds the unreserved contract
+     * balance (the contract balance minus the amount held in escrow on token holders'
+     * behalf).
+     *
+     * @param rescuableAmount The maximum amount of tokens that can be rescued
+     */
+    error RescuableAmountExceeded(int64 rescuableAmount);
+
+    /**
      * @dev Rescues `value` tokens from contractTokenOwner to rescuer
      *
      * @param amount The number of tokens to rescuer
@@ -46,4 +55,12 @@ interface IRescuable {
      * @param amount The number of tokens to rescuer
      */
     function rescueHBAR(uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the amount of tokens that can be rescued from the contract, i.e. the
+     * contract balance minus the amount held in escrow on token holders' behalf.
+     *
+     * @return amount_ The maximum amount of tokens that can be rescued
+     */
+    function getRescuableAmount() external view returns (int64 amount_);
 }

--- a/packages/contracts/contracts/extensions/RescuableFacet.sol
+++ b/packages/contracts/contracts/extensions/RescuableFacet.sol
@@ -29,10 +29,7 @@ contract RescuableFacet is
      * @param _amount The number of tokens to rescue
      */
     modifier checkRescueAmount(int64 _amount) {
-        int64 rescuableAmount = getRescuableAmount();
-        if (rescuableAmount < _amount) {
-            revert RescuableAmountExceeded(rescuableAmount);
-        }
+        _checkRescueAmount(_amount);
         _;
     }
 
@@ -102,10 +99,16 @@ contract RescuableFacet is
         amount_ = SafeCast.toInt64(SafeCast.toInt256(_balanceOf(address(this)))) - _holdDataStorage().totalHeldAmount;
     }
 
+    /**
+     * @dev Returns the resolver key that identifies this facet within the resolver.
+     */
     function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
         staticResolverKey_ = _RESCUABLE_RESOLVER_KEY;
     }
 
+    /**
+     * @dev Returns the list of function selectors exposed by this facet.
+     */
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
         uint256 selectorIndex;
         staticFunctionSelectors_ = new bytes4[](3);
@@ -114,9 +117,26 @@ contract RescuableFacet is
         staticFunctionSelectors_[selectorIndex++] = this.getRescuableAmount.selector;
     }
 
+    /**
+     * @dev Returns the list of interface ids implemented by this facet.
+     */
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
         staticInterfaceIds_ = new bytes4[](1);
         uint256 selectorsIndex;
         staticInterfaceIds_[selectorsIndex++] = type(IRescuable).interfaceId;
+    }
+
+    /**
+     * @dev Checks that the requested rescue amount does not exceed the unreserved
+     * contract balance (the contract balance minus the amount held in escrow on
+     * token holders' behalf).
+     *
+     * @param _amount The number of tokens to rescue
+     */
+    function _checkRescueAmount(int64 _amount) private view {
+        int64 rescuableAmount = getRescuableAmount();
+        if (rescuableAmount < _amount) {
+            revert RescuableAmountExceeded(rescuableAmount);
+        }
     }
 }

--- a/packages/contracts/contracts/extensions/RescuableFacet.sol
+++ b/packages/contracts/contracts/extensions/RescuableFacet.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.24;
 
 import {TokenOwnerStorageWrapper} from './TokenOwnerStorageWrapper.sol';
 import {RolesStorageWrapper} from './RolesStorageWrapper.sol';
+import {HoldManagementStorageWrapper} from './HoldManagementStorageWrapper.sol';
 import {IRescuable} from './Interfaces/IRescuable.sol';
 // solhint-disable-next-line max-line-length
 import {IHederaTokenService} from '@hashgraph/smart-contracts/contracts/system-contracts/hedera-token-service/IHederaTokenService.sol';
@@ -17,8 +18,24 @@ contract RescuableFacet is
     IRescuable,
     IStaticFunctionSelectors,
     TokenOwnerStorageWrapper,
-    RolesStorageWrapper
+    RolesStorageWrapper,
+    HoldManagementStorageWrapper
 {
+    /**
+     * @dev Checks that the requested rescue amount does not exceed the unreserved
+     * contract balance (the contract balance minus the amount held in escrow on
+     * token holders' behalf).
+     *
+     * @param _amount The number of tokens to rescue
+     */
+    modifier checkRescueAmount(int64 _amount) {
+        int64 rescuableAmount = getRescuableAmount();
+        if (rescuableAmount < _amount) {
+            revert RescuableAmountExceeded(rescuableAmount);
+        }
+        _;
+    }
+
     /**
      * @dev Rescues `value` `tokenId` from contractTokenOwner to rescuer
      *
@@ -33,7 +50,7 @@ contract RescuableFacet is
         override(IRescuable)
         onlyRole(_RESCUE_ROLE)
         greaterThanZero(amount)
-        notGreaterThan(SafeCast.toUint256(amount), _balanceOf(address(this)))
+        checkRescueAmount(amount)
         returns (bool)
     {
         address currentTokenAddress = _getTokenAddress();
@@ -77,15 +94,24 @@ contract RescuableFacet is
         return sent;
     }
 
+    /**
+     * @dev Returns the amount of tokens that can be rescued from the contract, i.e. the
+     * contract balance minus the amount held in escrow on token holders' behalf.
+     */
+    function getRescuableAmount() public view override(IRescuable) returns (int64 amount_) {
+        amount_ = SafeCast.toInt64(SafeCast.toInt256(_balanceOf(address(this)))) - _holdDataStorage().totalHeldAmount;
+    }
+
     function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
         staticResolverKey_ = _RESCUABLE_RESOLVER_KEY;
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
         uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](2);
+        staticFunctionSelectors_ = new bytes4[](3);
         staticFunctionSelectors_[selectorIndex++] = this.rescue.selector;
         staticFunctionSelectors_[selectorIndex++] = this.rescueHBAR.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getRescuableAmount.selector;
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {

--- a/packages/contracts/contracts/extensions/RescuableFacet.sol
+++ b/packages/contracts/contracts/extensions/RescuableFacet.sol
@@ -28,7 +28,7 @@ contract RescuableFacet is
      *
      * @param _amount The number of tokens to rescue
      */
-    modifier checkRescueAmount(int64 _amount) {
+    modifier onlyRescueAmount(int64 _amount) {
         _checkRescueAmount(_amount);
         _;
     }
@@ -47,7 +47,7 @@ contract RescuableFacet is
         override(IRescuable)
         onlyRole(_RESCUE_ROLE)
         greaterThanZero(amount)
-        checkRescueAmount(amount)
+        onlyRescueAmount(amount)
         returns (bool)
     {
         address currentTokenAddress = _getTokenAddress();

--- a/packages/contracts/test/thread1/hold.test.ts
+++ b/packages/contracts/test/thread1/hold.test.ts
@@ -10,6 +10,8 @@ import {
     HoldManagementFacet,
     CashInFacet,
     CashInFacet__factory,
+    RescuableFacet,
+    RescuableFacet__factory,
     StableCoinTokenMock__factory,
     IHRC__factory,
 } from '@contracts'
@@ -47,6 +49,7 @@ describe('➡️ Hold Management Tests', () => {
     let holdManagementFacet: HoldManagementFacet
     let cashInFacet: CashInFacet
     let burnableFacet: BurnableFacet
+    let rescuableFacet: RescuableFacet
 
     // Accounts
     let operator: SignerWithAddress
@@ -61,6 +64,7 @@ describe('➡️ Hold Management Tests', () => {
         holdManagementFacet = HoldManagementFacet__factory.connect(address, operator)
         cashInFacet = CashInFacet__factory.connect(address, operator)
         burnableFacet = BurnableFacet__factory.connect(address, operator)
+        rescuableFacet = RescuableFacet__factory.connect(address, operator)
     }
 
     async function checkCreatedHold_expected(
@@ -735,6 +739,53 @@ describe('➡️ Hold Management Tests', () => {
                 contract: burnableFacet,
                 customError: 'BurnableAmountExceeded',
             })
+        })
+    })
+
+    describe('Rescue when held amount greater than 0', () => {
+        beforeEach(async () => {
+            await setInitialData({})
+        })
+        it('GIVEN an active hold WHEN rescuing more than the unreserved balance THEN fails with RescuableAmountExceeded', async () => {
+            await expect(holdManagementFacet.createHold(hold)).to.emit(holdManagementFacet, 'HoldCreated')
+            await delay({ time: 1, unit: 'sec' })
+
+            // The held escrow is part of the contract balance but must NOT be rescuable
+            const contractBalance = await hederaTokenManagerFacet.balanceOf(stableCoinProxyAddress)
+            const heldAmount = await holdManagementFacet.getHeldAmount()
+            const rescuableAmount = await rescuableFacet.getRescuableAmount()
+            expect(rescuableAmount).to.equal(contractBalance - heldAmount)
+
+            // Trying to rescue the full contract balance (escrow included) must revert
+            await expectRevert({
+                txPromise: rescuableFacet.rescue(contractBalance, {
+                    gasLimit: GAS_LIMIT.hederaTokenManager.rescue,
+                }),
+                contract: rescuableFacet,
+                customError: 'RescuableAmountExceeded',
+                args: [rescuableAmount],
+            })
+        })
+        it('GIVEN an active hold WHEN rescuing only the unreserved balance THEN it succeeds and leaves the escrow intact', async () => {
+            await expect(holdManagementFacet.createHold(hold)).to.emit(holdManagementFacet, 'HoldCreated')
+            await delay({ time: 1, unit: 'sec' })
+
+            const heldAmount = await holdManagementFacet.getHeldAmount()
+            const rescuableAmount = await rescuableFacet.getRescuableAmount()
+
+            // Rescuing exactly the unreserved amount is allowed
+            const response = await rescuableFacet.rescue(rescuableAmount, {
+                gasLimit: GAS_LIMIT.hederaTokenManager.rescue,
+            })
+            await validateTxResponse(
+                new ValidateTxResponseCommand({ txResponse: response, confirmationEvent: 'TokenRescued' })
+            )
+            await delay({ time: 1, unit: 'sec' })
+
+            // The escrow backing the active hold must remain in the contract
+            const contractBalance = await hederaTokenManagerFacet.balanceOf(stableCoinProxyAddress)
+            expect(contractBalance).to.equal(heldAmount)
+            expect(await rescuableFacet.getRescuableAmount()).to.equal(0n)
         })
     })
 

--- a/packages/contracts/test/thread1/rescuable.test.ts
+++ b/packages/contracts/test/thread1/rescuable.test.ts
@@ -146,14 +146,17 @@ describe('➡️ Rescue Tests', function () {
         const TokenOwnerBalance = await hederaTokenManagerFacet.balanceOf(stableCoinProxyAddress, {
             gasLimit: GAS_LIMIT.hederaTokenManager.balanceOf,
         })
+        // With no active holds the rescuable amount equals the full contract balance
+        const rescuableAmount = await rescuableFacet.getRescuableAmount()
+        expect(rescuableAmount).to.equal(TokenOwnerBalance)
         // Rescue TokenOwnerBalance + 1 : fail
         await expectRevert({
             txPromise: rescuableFacet.rescue(TokenOwnerBalance + 1n, {
                 gasLimit: GAS_LIMIT.hederaTokenManager.rescue,
             }),
             contract: rescuableFacet,
-            customError: 'GreaterThan',
-            args: [TokenOwnerBalance + 1n, TokenOwnerBalance],
+            customError: 'RescuableAmountExceeded',
+            args: [rescuableAmount],
         })
     })
 

--- a/packages/sdk/__tests__/jest-setup-file.ts
+++ b/packages/sdk/__tests__/jest-setup-file.ts
@@ -1613,6 +1613,13 @@ jest.mock('../src/port/out/rpc/RPCQueryAdapter', () => {
 				.toString();
 		},
 	);
+	singletonInstance.getRescuableAmount = jest.fn(
+		async (address: EvmAddress) => {
+			return BigDecimal.fromString(totalSupply)
+				.subUnsafe(totalHeldAmount)
+				.toString();
+		},
+	);
 
 	return {
 		RPCQueryAdapter: jest.fn(() => singletonInstance),

--- a/packages/sdk/src/app/service/ValidationService.ts
+++ b/packages/sdk/src/app/service/ValidationService.ts
@@ -35,6 +35,8 @@ import { ExpiredHold } from '../../app/usecase/command/stablecoin/operations/hol
 import { HoldNotExpired } from '../../app/usecase/command/stablecoin/operations/hold/error/HoldNotExpired';
 import { GetBurnableAmountQuery } from '../../app/usecase/query/stablecoin/burn/getBurnableAmount/GetBurnableAmountQuery';
 import { BurnableAmountExceeded } from '../../app/usecase/command/stablecoin/operations/burn/error/BurnableAmountExceeded';
+import { GetRescuableAmountQuery } from '../../app/usecase/query/stablecoin/rescue/getRescuableAmount/GetRescuableAmountQuery';
+import { RescuableAmountExceeded } from '../../app/usecase/command/stablecoin/operations/rescue/error/RescuableAmountExceeded';
 
 export default class ValidationService extends Service {
 	constructor(
@@ -163,6 +165,18 @@ export default class ValidationService extends Service {
 		).payload;
 		if (burnableAmount.isLowerThan(BigDecimal.fromString(amount))) {
 			throw new BurnableAmountExceeded();
+		}
+	}
+
+	async checkRescuableAmount(
+		tokenId: HederaId,
+		amount: string,
+	): Promise<void> {
+		const rescuableAmount = (
+			await this.queryBus.execute(new GetRescuableAmountQuery(tokenId))
+		).payload;
+		if (rescuableAmount.isLowerThan(BigDecimal.fromString(amount))) {
+			throw new RescuableAmountExceeded();
 		}
 	}
 }

--- a/packages/sdk/src/app/usecase/command/stablecoin/operations/rescue/RescueCommandHandler.ts
+++ b/packages/sdk/src/app/usecase/command/stablecoin/operations/rescue/RescueCommandHandler.ts
@@ -28,6 +28,7 @@ import { StableCoinNotAssociated } from '../../error/StableCoinNotAssociated.js'
 import AccountService from '../../../../../service/AccountService.js';
 import StableCoinService from '../../../../../service/StableCoinService.js';
 import TransactionService from '../../../../../service/TransactionService.js';
+import ValidationService from '../../../../../service/ValidationService.js';
 
 import { DecimalsOverRange } from '../../error/DecimalsOverRange.js';
 import { OperationNotAllowed } from '../../error/OperationNotAllowed.js';
@@ -55,6 +56,8 @@ export class RescueCommandHandler implements ICommandHandler<RescueCommand> {
 		public readonly accountService: AccountService,
 		@lazyInject(TransactionService)
 		public readonly transactionService: TransactionService,
+		@lazyInject(ValidationService)
+		private readonly validationService: ValidationService,
 	) {}
 
 	async execute(command: RescueCommand): Promise<RescueCommandResponse> {
@@ -106,6 +109,9 @@ export class RescueCommandHandler implements ICommandHandler<RescueCommand> {
 				'The rescue amount is bigger than the treasury account balance',
 			);
 		}
+
+		await this.validationService.checkRescuableAmount(coin.tokenId, amount);
+
 		const res = await handler.rescue(capabilities, amountBd, startDate);
 		return Promise.resolve(
 			new RescueCommandResponse(res.error === undefined, res.id, res.serializedTransactionData),

--- a/packages/sdk/src/app/usecase/command/stablecoin/operations/rescue/error/RescuableAmountExceeded.ts
+++ b/packages/sdk/src/app/usecase/command/stablecoin/operations/rescue/error/RescuableAmountExceeded.ts
@@ -1,0 +1,32 @@
+/*
+ *
+ * Hedera Stablecoin SDK
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import BaseError, {
+	ErrorCode,
+} from '../../../../../../../core/error/BaseError.js';
+
+export class RescuableAmountExceeded extends BaseError {
+	constructor() {
+		super(
+			ErrorCode.RescuableAmountExceeded,
+			`Rescue amount greater than allowed`,
+		);
+	}
+}

--- a/packages/sdk/src/app/usecase/query/stablecoin/rescue/getRescuableAmount/GetRescuableAmountQuery.ts
+++ b/packages/sdk/src/app/usecase/query/stablecoin/rescue/getRescuableAmount/GetRescuableAmountQuery.ts
@@ -1,0 +1,33 @@
+/*
+ *
+ * Hedera Stablecoin SDK
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { BigDecimal, HederaId } from '../../../../../../port/in/StableCoin.js';
+import { Query } from '../../../../../../core/query/Query.js';
+import { QueryResponse } from '../../../../../../core/query/QueryResponse.js';
+
+export class GetRescuableAmountQueryResponse implements QueryResponse {
+	constructor(public readonly payload: BigDecimal) {}
+}
+
+export class GetRescuableAmountQuery extends Query<GetRescuableAmountQueryResponse> {
+	constructor(public readonly tokenId: HederaId) {
+		super();
+	}
+}

--- a/packages/sdk/src/app/usecase/query/stablecoin/rescue/getRescuableAmount/GetRescuableAmountQueryHandler.ts
+++ b/packages/sdk/src/app/usecase/query/stablecoin/rescue/getRescuableAmount/GetRescuableAmountQueryHandler.ts
@@ -1,0 +1,60 @@
+/*
+ *
+ * Hedera Stablecoin SDK
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {
+	GetRescuableAmountQuery,
+	GetRescuableAmountQueryResponse,
+} from './GetRescuableAmountQuery.js';
+import { QueryHandler } from '../../../../../../core/decorator/QueryHandlerDecorator.js';
+import { IQueryHandler } from '../../../../../../core/query/QueryHandler.js';
+import { RPCQueryAdapter } from '../../../../../../port/out/rpc/RPCQueryAdapter.js';
+import { lazyInject } from '../../../../../../core/decorator/LazyInjectDecorator.js';
+import StableCoinService from '../../../../../service/StableCoinService.js';
+import BigDecimal from '../../../../../../domain/context/shared/BigDecimal.js';
+
+@QueryHandler(GetRescuableAmountQuery)
+export class GetRescuableAmountQueryHandler
+	implements IQueryHandler<GetRescuableAmountQuery>
+{
+	constructor(
+		@lazyInject(StableCoinService)
+		private readonly stableCoinService: StableCoinService,
+		@lazyInject(RPCQueryAdapter)
+		private readonly queryAdapter: RPCQueryAdapter,
+	) {}
+
+	async execute(
+		command: GetRescuableAmountQuery,
+	): Promise<GetRescuableAmountQueryResponse> {
+		const { tokenId } = command;
+
+		const coin = await this.stableCoinService.get(tokenId);
+
+		if (!coin.evmProxyAddress) throw new Error('Invalid token id');
+
+		const res = await this.queryAdapter.getRescuableAmount(
+			coin.evmProxyAddress,
+		);
+
+		const amount = BigDecimal.fromStringFixed(res, coin.decimals);
+
+		return Promise.resolve(new GetRescuableAmountQueryResponse(amount));
+	}
+}

--- a/packages/sdk/src/core/Injectable.ts
+++ b/packages/sdk/src/core/Injectable.ts
@@ -113,6 +113,7 @@ import { GetHoldForQueryHandler } from '../app/usecase/query/stablecoin/hold/get
 import { GetHeldAmountForQueryHandler } from '../app/usecase/query/stablecoin/hold/getHeldAmountFor/GetHeldAmountForQueryHandler.js';
 import { GetHoldCountForQueryHandler } from '../app/usecase/query/stablecoin/hold/getHoldCountFor/GetHoldCountForQueryHandler.js';
 import { GetBurnableAmountQueryHandler } from '../app/usecase/query/stablecoin/burn/getBurnableAmount/GetBurnableAmountQueryHandler.js';
+import { GetRescuableAmountQueryHandler } from '../app/usecase/query/stablecoin/rescue/getRescuableAmount/GetRescuableAmountQueryHandler.js';
 import { GetAccountAutoAssociationQueryHandler } from '../app/usecase/query/account/autoAssociation/GetAccountAutoAssociationQueryHandler';
 import { ClientTransactionAdapter } from '../port/out/hs/client/ClientTransactionAdapter.js';
 import { ExternalHederaTransactionAdapter } from '../port/out/hs/external/ExternalHederaTransactionAdapter.js';
@@ -413,6 +414,10 @@ const QUERY_HANDLERS = [
 	{
 		token: TOKENS.QUERY_HANDLER,
 		useClass: GetBurnableAmountQueryHandler,
+	},
+	{
+		token: TOKENS.QUERY_HANDLER,
+		useClass: GetRescuableAmountQueryHandler,
 	},
 ];
 

--- a/packages/sdk/src/core/error/BaseError.ts
+++ b/packages/sdk/src/core/error/BaseError.ts
@@ -56,6 +56,7 @@ export enum ErrorCode {
 	ExpiredHold = '20014',
 	HoldNotExpired = '20015',
 	BurnableAmountExceeded = '20016',
+	RescuableAmountExceeded = '20017',
 	ReceiptNotReceived = '30001',
 	ContractNotFound = '30002',
 	Unexpected = '30003',

--- a/packages/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -39,6 +39,7 @@ import {
 	DiamondFacet__factory,
 	HoldManagementFacet__factory,
 	BurnableFacet__factory,
+	RescuableFacet__factory,
 } from '@hashgraph/stablecoin-npm-contracts';
 import { StableCoinRole } from '../../../domain/context/stablecoin/StableCoinRole.js';
 import ContractId from '../../../domain/context/contract/ContractId.js';
@@ -334,5 +335,16 @@ export class RPCQueryAdapter {
 		).getBurnableAmount();
 
 		return burnableAmount.toString();
+	}
+
+	async getRescuableAmount(address: EvmAddress): Promise<string> {
+		LogService.logTrace(`Getting rescuable amount`);
+
+		const rescuableAmount = await this.connect(
+			RescuableFacet__factory,
+			address.toString(),
+		).getRescuableAmount();
+
+		return rescuableAmount.toString();
 	}
 }


### PR DESCRIPTION
Summary
Fixes a Medium-severity vulnerability (reported by the security audit) where the rescue operation could drain stablecoin tokens held in escrow on behalf of token holders.

When a hold is created, the holder's tokens are wiped and an equivalent amount is minted into the stablecoin contract (the treasury) as escrow, tracked by totalHeldAmount. The rescue function only checked the contract's raw token balance and did not subtract the held obligations, so an account with the _RESCUE_ROLE could transfer out the escrow backing active holds — leaving hold records without backing tokens and causing executeHold / releaseHold / reclaimHold to fail.

This aligns rescue with the existing burn logic, which already excludes held amounts via getBurnableAmount().

Changes
Contracts

RescuableFacet.sol: added getRescuableAmount() (balanceOf(contract) − totalHeldAmount) and a checkRescueAmount modifier; rescue() now validates against the rescuable (unreserved) amount instead of the raw contract balance. Registered the new selector.
IRescuable.sol: added the getRescuableAmount() signature and the RescuableAmountExceeded(int64 rescuableAmount) error.
SDK (mirrors the existing burn flow)

New GetRescuableAmountQuery + handler and RescuableAmountExceeded domain error (ErrorCode 20017).
RPCQueryAdapter.getRescuableAmount() calling the new contract view.
ValidationService.checkRescuableAmount() and a pre-flight check in RescueCommandHandler (kept the existing treasury-balance check as well).
Registered the query handler in Injectable.
Tests
hold.test.ts: new "Rescue when held amount greater than 0" block (mirrors the existing burn-with-hold test) — rescuing the full balance with an active hold reverts with RescuableAmountExceeded; rescuing only the unreserved amount succeeds and leaves the escrow intact.
rescuable.test.ts: updated the over-balance case to assert the new RescuableAmountExceeded error.
jest-setup-file.ts: mocked getRescuableAmount.